### PR TITLE
TableNotFound exception in cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ of a given type, e.g. FieldValue.isInteger(), etc.
 ### Fixed
 - Use correct netty constructor when using an HTTP proxy without a username or
 password
+- Fixed a problem where the cloud service might succeed when dropping a table
+that does not exist without using "drop table if exists" when it should throw
+TableNotFoundException
 
 ## 5.2.26 - 2021-02-09
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableResult.java
@@ -381,13 +381,6 @@ public class TableResult extends Result {
             } catch (InterruptedException ie) {
                 throw new NoSQLException("waitForState interrupted: " +
                                          ie.getMessage());
-            } catch (TableNotFoundException tnf) {
-                /* table not found is == DROPPED */
-                if (state == State.DROPPED) {
-                    return new TableResult().setState(State.DROPPED).
-                        setTableName(tableName);
-                }
-                throw tnf;
             }
         } while (!res.getTableState().equals(state));
 
@@ -473,13 +466,6 @@ public class TableResult extends Result {
             } catch (InterruptedException ie) {
                 throw new NoSQLException("waitForCompletion interrupted: " +
                                          ie.getMessage());
-            } catch (TableNotFoundException tnf) {
-                /*
-                 * The operation was probably a drop. There was an operationId,
-                 * which means that the table existed when the original
-                 * request was made. Throwing tnf doesn't add value here.
-                 */
-                state = State.DROPPED;
             }
         }
     }

--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -85,6 +85,17 @@ public class BasicTest extends ProxyTestBase {
             assertNotNull(tres.getTableName());
             assertNull(tres.getTableLimits());
 
+            /* drop again without if exists -- should throw */
+            try {
+                tres = tableOperation(handle,
+                                      "drop table testusers",
+                                      null);
+                fail("operation should have thrown");
+            } catch (TableNotFoundException tnfe) {
+                // success
+            }
+
+
             /* Create a table */
             tres = tableOperation(
                 handle,


### PR DESCRIPTION
Fixed a problem where the cloud service might succeed when dropping a table
that does not exist when it should have thrown a TableNotFound exception.