### PR TITLE
Support for On-Demand tables, modification time, durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Cloud only: Support for On-Demand tables in TableLimits
+- Row modification time made available in GetResult
+- Existing row modification time made available in PutResult and DeleteResult when operation fails and previous value is requested
+- On-Prem only: Support for setting Durability in write operations (put/delete/writeMultiple/multiDelete)
+
+### Changed
+- Internally, the SDK now detects the serial version of the server it's connected to, and adjusts its capabilities to match. If the server is an older version, and some features may not be available, client apps may get a one-time log message (at INFO level) with text like "The requested feature is not supported by the connected server".
+
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
@@ -50,7 +62,7 @@ NoSQLHandleConfig.setPoolMaxPending() and NoSQLHandleConfig.getPoolMaxPending().
   - Added new SignatureProvider constructors to allow use of an instance principal with delegation token in a file for authorization and authentication.
     - SignatureProvider.createInstancePrincipalForDelegation(File delegationTokenFile)
     - SignatureProvider.createInstancePrincipalForDelegation(String iamAuthUri, Region region, File delegationTokenFile, Logger logger)
-- Added is* methods on FieldValue for convenience checking of whether an instance is
+- Added methods on FieldValue for convenience checking of whether an instance is
 of a given type, e.g. FieldValue.isInteger(), etc.
 
 ### Changed

--- a/driver/src/main/java/oracle/nosql/driver/Durability.java
+++ b/driver/src/main/java/oracle/nosql/driver/Durability.java
@@ -1,0 +1,232 @@
+/*-
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+/**
+ * Defines the durability characteristics associated with a standalone write
+ * (put or update) operation.
+ * <p>
+ * This is currently only supported in On-Prem installations. It is ignored
+ * in the cloud service.
+ * <p>
+ * The overall durability is a function of the {@link SyncPolicy} and {@link
+ * ReplicaAckPolicy} in effect for the Master, and the {@link SyncPolicy} in
+ * effect for each Replica.
+ * </p>
+ */
+public class Durability {
+
+    /**
+     * A convenience constant that defines a durability policy with COMMIT_SYNC
+     * for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_SYNC =
+        new Durability(SyncPolicy.SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * A convenience constant that defines a durability policy with
+     * COMMIT_NO_SYNC for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_NO_SYNC =
+        new Durability(SyncPolicy.NO_SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * A convenience constant that defines a durability policy with
+     * COMMIT_WRITE_NO_SYNC for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_WRITE_NO_SYNC =
+        new Durability(SyncPolicy.WRITE_NO_SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * Defines the synchronization policy to be used when committing a
+     * transaction. High levels of synchronization offer a greater guarantee
+     * that the transaction is persistent to disk, but trade that off for
+     * lower performance.
+     */
+    public enum SyncPolicy {
+
+        /**
+         *  Write and synchronously flush the log on transaction commit.
+         *  Transactions exhibit all the ACID (atomicity, consistency,
+         *  isolation, and durability) properties.
+         */
+        SYNC,
+
+        /**
+         * Do not write or synchronously flush the log on transaction commit.
+         * Transactions exhibit the ACI (atomicity, consistency, and isolation)
+         * properties, but not D (durability); that is, database integrity will
+         * be maintained, but if the application or system fails, it is
+         * possible some number of the most recently committed transactions may
+         * be undone during recovery. The number of transactions at risk is
+         * governed by how many log updates can fit into the log buffer, how
+         * often the operating system flushes dirty buffers to disk, and how
+         * often log checkpoints occur.
+         */
+        NO_SYNC,
+
+        /**
+         * Write but do not synchronously flush the log on transaction commit.
+         * Transactions exhibit the ACI (atomicity, consistency, and isolation)
+         * properties, but not D (durability); that is, database integrity will
+         * be maintained, but if the operating system fails, it is possible
+         * some number of the most recently committed transactions may be
+         * undone during recovery. The number of transactions at risk is
+         * governed by how often the operating system flushes dirty buffers to
+         * disk, and how often log checkpoints occur.
+         */
+        WRITE_NO_SYNC;
+    }
+
+    /**
+     * A replicated environment makes it possible to increase an application's
+     * transaction commit guarantees by committing changes to its replicas on
+     * the network. ReplicaAckPolicy defines the policy for how such network
+     * commits are handled.
+     */
+    public enum ReplicaAckPolicy {
+
+        /**
+         * All replicas must acknowledge that they have committed the
+         * transaction. This policy should be selected only if your replication
+         * group has a small number of replicas, and those replicas are on
+         * extremely reliable networks and servers.
+         */
+        ALL,
+
+        /**
+         * No transaction commit acknowledgments are required and the master
+         * will never wait for replica acknowledgments. In this case,
+         * transaction durability is determined entirely by the type of commit
+         * that is being performed on the master.
+         */
+        NONE,
+
+        /**
+         * A simple majority of replicas must acknowledge that they have
+         * committed the transaction. This acknowledgment policy, in
+         * conjunction with an election policy which requires at least a simple
+         * majority, ensures that the changes made by the transaction remains
+         * durable if a new election is held.
+         */
+        SIMPLE_MAJORITY;
+    }
+
+    /* The sync policy in effect on the Master node. */
+    private final SyncPolicy masterSync;
+
+    /* The sync policy in effect on a replica. */
+    final private SyncPolicy replicaSync;
+
+    /* The replica acknowledgment policy to be used. */
+    final private ReplicaAckPolicy replicaAck;
+
+    /**
+     * Creates an instance of a Durability specification.
+     *
+     * @param masterSync the SyncPolicy to be used when committing the
+     * transaction on the Master.
+     * @param replicaSync the SyncPolicy to be used remotely, as part of a
+     * transaction acknowledgment, at a Replica node.
+     * @param replicaAck the acknowledgment policy used when obtaining
+     * transaction acknowledgments from Replicas.
+     */
+    public Durability(SyncPolicy masterSync,
+                      SyncPolicy replicaSync,
+                      ReplicaAckPolicy replicaAck) {
+        this.masterSync = masterSync;
+        this.replicaSync = replicaSync;
+        this.replicaAck = replicaAck;
+    }
+
+    @Override
+    public String toString() {
+        return masterSync.toString() + "," +
+               replicaSync.toString() + "," +
+               replicaAck.toString();
+    }
+
+    /**
+     * Returns the transaction synchronization policy to be used on the Master
+     * when committing a transaction.
+     * @return the master transaction synchronization policy
+     */
+    public SyncPolicy getMasterSync() {
+        return masterSync;
+    }
+
+    /**
+     * Returns the transaction synchronization policy to be used by the replica
+     * as it replays a transaction that needs an acknowledgment.
+     * @return the replica transaction synchronization policy
+     */
+    public SyncPolicy getReplicaSync() {
+        return replicaSync;
+    }
+
+    /**
+     * Returns the replica acknowledgment policy used by the master when
+     * committing changes to a replicated environment.
+     * @return the replica acknowledgment policy
+     */
+    public ReplicaAckPolicy getReplicaAck() {
+        return replicaAck;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = (prime * result) + masterSync.hashCode();
+        result = (prime * result) + replicaAck.hashCode();
+        result = (prime * result) + replicaSync.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Durability)) {
+            return false;
+        }
+        Durability other = (Durability) obj;
+        if (!masterSync.equals(other.masterSync)) {
+            return false;
+        }
+        if (!replicaAck.equals(other.replicaAck)) {
+            return false;
+        }
+        if (!replicaSync.equals(other.replicaSync)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -150,7 +150,7 @@ public class NoSQLHandleConfig implements Cloneable {
     private List<String> ciphers;
 
     /**
-     * The protocols used by the driver, or null if not configured
+     * The SSL protocols used by the driver, or null if not configured
      * by the user.
      */
     private List<String> protocols;

--- a/driver/src/main/java/oracle/nosql/driver/UnsupportedProtocolException.java
+++ b/driver/src/main/java/oracle/nosql/driver/UnsupportedProtocolException.java
@@ -1,0 +1,24 @@
+/*-
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+/**
+ * The server does not support the current driver protocol version.
+ */
+public class UnsupportedProtocolException extends NoSQLException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @hidden
+     * @param msg the exception message
+     */
+    public UnsupportedProtocolException(String msg) {
+        super(msg);
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -10,7 +10,16 @@ package oracle.nosql.driver.http;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static oracle.nosql.driver.ops.TableLimits.CapacityMode;
+import static oracle.nosql.driver.util.BinaryProtocol.DEFAULT_SERIAL_VERSION;
+import static oracle.nosql.driver.util.BinaryProtocol.V2;
+import static oracle.nosql.driver.util.BinaryProtocol.V3;
 import static oracle.nosql.driver.util.CheckNull.requireNonNull;
+import static oracle.nosql.driver.util.LogUtil.isLoggable;
+import static oracle.nosql.driver.util.LogUtil.logFine;
+import static oracle.nosql.driver.util.LogUtil.logInfo;
+import static oracle.nosql.driver.util.LogUtil.logTrace;
+import static oracle.nosql.driver.util.LogUtil.logWarning;
 import static oracle.nosql.driver.util.HttpConstants.ACCEPT;
 import static oracle.nosql.driver.util.HttpConstants.CONNECTION;
 import static oracle.nosql.driver.util.HttpConstants.CONTENT_LENGTH;
@@ -18,13 +27,10 @@ import static oracle.nosql.driver.util.HttpConstants.CONTENT_TYPE;
 import static oracle.nosql.driver.util.HttpConstants.NOSQL_DATA_PATH;
 import static oracle.nosql.driver.util.HttpConstants.REQUEST_ID_HEADER;
 import static oracle.nosql.driver.util.HttpConstants.USER_AGENT;
-import static oracle.nosql.driver.util.LogUtil.isLoggable;
-import static oracle.nosql.driver.util.LogUtil.logFine;
-import static oracle.nosql.driver.util.LogUtil.logInfo;
-import static oracle.nosql.driver.util.LogUtil.logTrace;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -51,17 +57,22 @@ import oracle.nosql.driver.RetryableException;
 import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.StatsControl;
 import oracle.nosql.driver.WriteThrottlingException;
+import oracle.nosql.driver.UnsupportedProtocolException;
 import oracle.nosql.driver.httpclient.HttpClient;
 import oracle.nosql.driver.httpclient.ResponseHandler;
 import oracle.nosql.driver.kv.AuthenticationException;
 import oracle.nosql.driver.kv.StoreAccessTokenProvider;
+import oracle.nosql.driver.ops.DurableRequest;
+import oracle.nosql.driver.ops.GetResult;
 import oracle.nosql.driver.ops.GetTableRequest;
 import oracle.nosql.driver.ops.QueryRequest;
 import oracle.nosql.driver.ops.QueryResult;
 import oracle.nosql.driver.ops.Request;
 import oracle.nosql.driver.ops.Result;
 import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableRequest;
 import oracle.nosql.driver.ops.TableResult;
+import oracle.nosql.driver.ops.WriteResult;
 import oracle.nosql.driver.ops.serde.BinaryProtocol;
 import oracle.nosql.driver.ops.serde.BinarySerializerFactory;
 import oracle.nosql.driver.ops.serde.SerializerFactory;
@@ -151,6 +162,11 @@ public class Client {
      */
     private ExecutorService threadPool;
 
+    private short serialVersion = DEFAULT_SERIAL_VERSION;
+
+    /* for one-time messages */
+    private final HashSet<String> oneTimeMessages;
+
     /**
      * config for statistics
      */
@@ -225,6 +241,7 @@ public class Client {
             threadPool = null;
         }
 
+        oneTimeMessages = new HashSet<String>();
         statsControl = new StatsControlImpl(config,
             logger, httpClient, httpConfig.getRateLimitingEnabled());
     }
@@ -440,6 +457,23 @@ public class Client {
                 logRetries(kvRequest.getNumRetries(), exception);
             }
 
+            if (serialVersion < 3 && kvRequest instanceof DurableRequest) {
+                if (((DurableRequest)kvRequest).getDurability() != null) {
+                    oneTimeMessage("The requested feature is not supported " +
+                                   "by the connected server: Durability");
+                }
+            }
+
+            if (serialVersion < 3 && kvRequest instanceof TableRequest) {
+                TableLimits limits = ((TableRequest)kvRequest).getTableLimits();
+                if (limits != null &&
+                    limits.getMode() == CapacityMode.ON_DEMAND) {
+                    oneTimeMessage("The requested feature is not supported " +
+                                   "by the connected server: on demand " +
+                                   "capacity table");
+                }
+            }
+
             ResponseHandler responseHandler = null;
 
             ByteBuf buffer = null;
@@ -533,6 +567,16 @@ public class Client {
                                        kvRequest);
                 int resSize = wireContent.readerIndex();
                 networkLatency = System.currentTimeMillis() - networkLatency;
+
+                if (serialVersion < 3) {
+                    /* so we can emit a one-time message if the app */
+                    /* tries to access modificationTime */
+                    if (res instanceof GetResult) {
+                        ((GetResult)res).setClient(this);
+                    } else if (res instanceof WriteResult) {
+                        ((WriteResult)res).setClient(this);
+                    }
+                }
 
                 if (res instanceof TableResult && rateLimiterMap != null) {
                     /* update rate limiter settings for table */
@@ -638,6 +682,16 @@ public class Client {
                 kvRequest.incrementRetries();
                 exception = re;
                 continue;
+            } catch (UnsupportedProtocolException upe) {
+                /* reduce protocol version and try again */
+                if (decrementSerialVersion() == true) {
+                    exception = upe;
+                    logInfo(logger, "Got unsupported protocol error " +
+                            "from server: decrementing serial version to " +
+                            serialVersion + " and trying again.");
+                    continue;
+                }
+                throw upe;
             } catch (NoSQLException nse) {
                 kvRequest.setRateLimitDelayedMs(rateDelayedMs);
                 statsControl.observeError(kvRequest);
@@ -875,10 +929,10 @@ public class Client {
         throws IOException {
 
         final NettyByteOutputStream bos = new NettyByteOutputStream(content);
-        BinaryProtocol.writeSerialVersion(bos);
+        bos.writeShort(serialVersion);
         kvRequest.createSerializer(factory).
             serialize(kvRequest,
-                      BinaryProtocol.getSerialVersion(),
+                      serialVersion,
                       bos);
     }
 
@@ -921,7 +975,7 @@ public class Client {
                 Result res = kvRequest.createDeserializer(factory).
                              deserialize(kvRequest,
                                          in,
-                                         BinaryProtocol.getSerialVersion());
+                                         serialVersion);
 
                 if (kvRequest.isQueryRequest()) {
                     QueryRequest qreq = (QueryRequest)kvRequest;
@@ -1169,5 +1223,39 @@ public class Client {
      */
     StatsControl getStatsControl() {
         return statsControl;
+    }
+
+    /**
+     * @hidden
+     *
+     * Try to decrement the serial protocol version.
+     * @return true: version was decremented
+     *         false: already at lowest version number.
+     */
+    public boolean decrementSerialVersion() {
+        if (serialVersion == V3) {
+            serialVersion = V2;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @hidden
+     * For testing use
+     */
+    public short getSerialVersion() {
+        return serialVersion;
+    }
+
+    /**
+     * @hidden
+     * for internal use
+     */
+    public synchronized void oneTimeMessage(String msg) {
+        if (oneTimeMessages.add(msg) == false) {
+            return;
+        }
+        logWarning(logger, msg);
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
@@ -391,4 +391,12 @@ public class NoSQLHandleImpl implements NoSQLHandle {
     public Client getClient() {
         return client;
     }
+
+    /**
+     * @hidden
+     * For testing use
+     */
+    public short getSerialVersion() {
+        return client.getSerialVersion();
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
@@ -7,6 +7,7 @@
 
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.Version;
@@ -149,6 +150,19 @@ public class DeleteRequest extends WriteRequest {
      */
     public DeleteRequest setTableName(String tableName) {
         super.setTableNameInternal(tableName);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value
+     *
+     * @return this
+     */
+    public DeleteRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteResult.java
@@ -57,6 +57,18 @@ public class DeleteResult extends WriteResult {
         return super.getExistingValueInternal();
     }
 
+    /**
+     * Returns the existing modification time if available. This is available
+     * only if the target row exists and the operation failed because of a
+     * {@link Version} mismatch and the corresponding {@link DeleteRequest}
+     * method {@link DeleteRequest#setReturnRow} was called with a true value.
+     *
+     * @return the modification time in milliseconds since Jan 1, 1970
+     */
+    public long getExistingModificationTime() {
+        return super.getExistingModificationTimeInternal();
+    }
+
     /* from Result */
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
@@ -1,0 +1,45 @@
+/*-
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.ops;
+
+import oracle.nosql.driver.Durability;
+
+/**
+ * @hidden
+ *
+ * Represents a base class for operations that support a
+ * {@link Durability} setting.
+ */
+public abstract class DurableRequest extends Request {
+
+    private Durability durability;
+
+    protected DurableRequest() {}
+
+    protected void setDurabilityInternal(Durability durability) {
+        this.durability = durability;
+    }
+
+    /**
+     * Returns the durability setting for this operation.
+     * On-prem only.
+     *
+     * @return durability, if set. Otherwise null.
+     */
+    public Durability getDurability() {
+        return durability;
+    }
+
+    /**
+     * @hidden
+     */
+    @Override
+    public boolean doesWrites() {
+        return true;
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetResult.java
@@ -10,6 +10,7 @@ package oracle.nosql.driver.ops;
 import oracle.nosql.driver.Consistency;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.Version;
+import oracle.nosql.driver.http.Client;
 import oracle.nosql.driver.values.MapValue;
 
 /**
@@ -26,6 +27,8 @@ public class GetResult extends Result {
     private MapValue value;
     private Version version;
     private long expirationTime;
+    private long modificationTime;
+    private Client client;
 
     /**
      * Returns the value of the returned row, or null if the row does not exist
@@ -69,6 +72,23 @@ public class GetResult extends Result {
     }
 
     /**
+     * Returns the modification time of the row.
+     * This value is valid only if the operation
+     * successfully returned a row ({@link #getValue} returns non-null).
+     *
+     * @return the modification time in milliseconds since January 1, 1970,
+     * or zero if the row does not exist
+     */
+    public long getModificationTime() {
+        if (modificationTime < 0 && client != null) {
+            client.oneTimeMessage("The requested feature is not supported by " +
+                                  "the connected server: getModificationTime");
+            return 0;
+        }
+        return modificationTime;
+    }
+
+    /**
      * @hidden
      * Internal use only.
      *
@@ -95,6 +115,21 @@ public class GetResult extends Result {
      */
     public GetResult setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
+        return this;
+    }
+
+    /**
+     * @hidden
+     * Internal use only.
+     *
+     * Sets the modification time.
+     *
+     * @param modificationTime the modification time
+     *
+     * @return this
+     */
+    public GetResult setModificationTime(long modificationTime) {
+        this.modificationTime = modificationTime;
         return this;
     }
 
@@ -160,5 +195,13 @@ public class GetResult extends Result {
     @Override
     public String toString() {
         return getJsonValue();
+    }
+
+    /*
+     * @hidden
+     * for internal use
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -6,6 +6,7 @@
  */
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.FieldRange;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
@@ -34,7 +35,7 @@ import oracle.nosql.driver.values.MapValue;
  * key still require the primary key.
  * @see NoSQLHandle#multiDelete
  */
-public class MultiDeleteRequest extends Request {
+public class MultiDeleteRequest extends DurableRequest {
 
     private MapValue key;
     private byte[] continuationKey;
@@ -191,6 +192,20 @@ public class MultiDeleteRequest extends Request {
      */
     public MultiDeleteRequest setTimeout(int timeoutMs) {
         super.setTimeoutInternal(timeoutMs);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     */
+    public MultiDeleteRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
@@ -7,6 +7,7 @@
 
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.TimeToLive;
@@ -304,6 +305,20 @@ public class PutRequest extends WriteRequest {
      */
     public PutRequest setReturnRow(boolean value) {
         super.setReturnRowInternal(value);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     */
+    public PutRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutResult.java
@@ -71,6 +71,18 @@ public class PutResult extends WriteResult {
         return super.getExistingValueInternal();
     }
 
+    /**
+     * Returns the existing modification time if available. This value will
+     * only be available if the conditional put operation failed and the request
+     * specified that return information be returned using
+     * {@link PutRequest#setReturnRow}.
+     *
+     * @return the existing modification time in milliseconds since Jan 1, 1970
+     */
+    public long getExistingModificationTime() {
+        return super.getExistingModificationTimeInternal();
+    }
+
     /* from Result */
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableLimits.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableLimits.java
@@ -38,12 +38,21 @@ import oracle.nosql.driver.NoSQLHandle;
  */
 public class TableLimits {
 
+    /**
+     * Table limits option
+     */
+    public enum CapacityMode {
+        PROVISIONED,
+        ON_DEMAND;
+    }
+
     private int readUnits;
     private int writeUnits;
     private int storageGB;
+    private CapacityMode mode;
 
     /**
-     * Constructs a TableLimits instance.
+     * Constructs a TableLimits instance for provisioned capacity table.
      *
      * @param readUnits the desired throughput of read operation in terms of
      * read units. A read unit represents 1 eventually consistent read
@@ -61,9 +70,46 @@ public class TableLimits {
     public TableLimits(int readUnits,
                        int writeUnits,
                        int storageGB) {
+        this(readUnits, writeUnits, storageGB, CapacityMode.PROVISIONED);
+    }
+
+    /**
+     * Constructs a TableLimits instance for on demand capacity table.
+     *
+     * @param storageGB the maximum storage to be consumed by the table, in
+     * gigabytes
+     */
+    public TableLimits(int storageGB) {
+        this(0, 0, storageGB, CapacityMode.ON_DEMAND);
+    }
+
+    /**
+     * @hidden
+     * Limits constructor for read from response.
+     *
+     * @param readUnits the desired throughput of read operation in terms of
+     * read units. A read unit represents 1 eventually consistent read
+     * per second for data up to 1 KB in size. A read that is absolutely
+     * consistent is double that, consuming 2 read units for a read of up to
+     * 1 KB in size. See {@link Consistency}.
+     *
+     * @param writeUnits the desired throughput of write operation in terms of
+     * write units. A write unit represents 1 write per second of data up to
+     * 1 KB in size.
+     *
+     * @param storageGB the maximum storage to be consumed by the table, in
+     * gigabytes
+     *
+     * @param mode the capacity mode used by the table.
+     */
+    public TableLimits(int readUnits,
+                       int writeUnits,
+                       int storageGB,
+                       CapacityMode mode) {
         this.readUnits = readUnits;
         this.writeUnits = writeUnits;
         this.storageGB = storageGB;
+        this.mode = mode;
     }
 
     /**
@@ -88,6 +134,14 @@ public class TableLimits {
      */
     public int getStorageGB() {
         return storageGB;
+    }
+
+    /**
+     * Returns the capacity mode
+     * @return capacity mode
+     */
+    public CapacityMode getMode() {
+        return mode;
     }
 
     /**
@@ -136,9 +190,25 @@ public class TableLimits {
      * @hidden
      */
     void validate() {
-        if (readUnits <= 0 || writeUnits <= 0 || storageGB <= 0) {
+        if (storageGB <= 0) {
             throw new IllegalArgumentException(
-                "TableLimits values must be non-negative");
+                "storageGB must be non-negative");
+        }
+        switch (mode) {
+        case PROVISIONED:
+            if (readUnits <= 0 || writeUnits <= 0) {
+                throw new IllegalArgumentException(
+                    "readUnits and writeUnits must be non-negative for " +
+                    "provisioned capacity table");
+            }
+            break;
+        case ON_DEMAND:
+            if (readUnits > 0 || writeUnits > 0) {
+                throw new IllegalArgumentException(
+                    "Cannot set readUnits or writeUnits for " +
+                    "on demand capacity table");
+            }
+            break;
         }
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oracle.nosql.driver.BatchOperationNumberLimitException;
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.iam.SignatureProvider;
@@ -39,7 +40,7 @@ import oracle.nosql.driver.ops.serde.SerializerFactory;
  * {@link WriteMultipleResult#getFailedOperationResult()}.
  * @see NoSQLHandle#writeMultiple
  */
-public class WriteMultipleRequest extends Request {
+public class WriteMultipleRequest extends DurableRequest {
 
     /* The list of requests */
     private final List<OperationRequest> operations;
@@ -155,6 +156,20 @@ public class WriteMultipleRequest extends Request {
     public void clear() {
         super.setTableNameInternal(null);
         operations.clear();
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     */
+    public WriteMultipleRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
+        return this;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleResult.java
@@ -217,6 +217,15 @@ public class WriteMultipleResult extends Result {
         }
 
         /**
+         * Returns the previous modification time associated with the key if
+         * available.
+         * @return the modification time if set, in milliseconds sine Jan 1, 1970
+         */
+        public long getExistingModificationTime() {
+            return super.getExistingModificationTimeInternal();
+        }
+
+        /**
          * Returns the value generated if the operation created a new value.
          * This can happen if the table contains an identity column or string
          * column declared as a generated UUID. If the table has no such

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
@@ -21,7 +21,7 @@ import oracle.nosql.driver.NoSQLHandleConfig;
  * about the existing value of the target row on failure. By default
  * no previous information is returned.
  */
-public abstract class WriteRequest extends Request {
+public abstract class WriteRequest extends DurableRequest {
 
     private boolean returnRow;
 
@@ -56,13 +56,5 @@ public abstract class WriteRequest extends Request {
                 (requestName +
                  " requires table name"));
         }
-    }
-
-    /**
-     * @hidden
-     */
-    @Override
-    public boolean doesWrites() {
-        return true;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteResult.java
@@ -9,6 +9,7 @@ package oracle.nosql.driver.ops;
 
 import oracle.nosql.driver.Version;
 import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.http.Client;
 
 /**
  * @hidden
@@ -19,6 +20,8 @@ import oracle.nosql.driver.values.MapValue;
 public class WriteResult extends Result {
     private Version existingVersion;
     private MapValue existingValue;
+    private long existingModificationTime;
+    private Client client;
 
     protected WriteResult() {}
 
@@ -37,6 +40,19 @@ public class WriteResult extends Result {
      */
     public MapValue getExistingValueInternal() {
         return existingValue;
+    }
+
+    /**
+     * @hidden
+     * @return the modification time
+     */
+    public long getExistingModificationTimeInternal() {
+        if (existingModificationTime < 0 && client != null) {
+            client.oneTimeMessage("The requested feature is not supported by " +
+                          "the connected server: getExistingModificationTime");
+            return 0;
+        }
+        return existingModificationTime;
     }
 
     /*
@@ -61,5 +77,24 @@ public class WriteResult extends Result {
     public WriteResult setExistingValue(MapValue existingValue) {
         this.existingValue = existingValue;
         return this;
+    }
+
+    /**
+     * @hidden
+     * @param existingModificationTime the modification time
+     * @return this
+     */
+    public WriteResult setExistingModificationTime(
+        long existingModificationTime) {
+        this.existingModificationTime = existingModificationTime;
+        return this;
+    }
+
+    /*
+     * @hidden
+     * for internal use
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/DeleteRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/DeleteRequestSerializer.java
@@ -51,7 +51,7 @@ class DeleteRequestSerializer extends BinaryProtocol implements Serializer {
         if (isSubRequest) {
             out.writeBoolean(deleteRq.getReturnRow());
         } else {
-            serializeWriteRequest(deleteRq,out);
+            serializeWriteRequest(deleteRq, out, serialVersion);
         }
         writeFieldValue(out, deleteRq.getKey());
         if (matchVersion != null) {
@@ -69,7 +69,7 @@ class DeleteRequestSerializer extends BinaryProtocol implements Serializer {
         deserializeConsumedCapacity(in, result);
         boolean success = in.readBoolean();
         result.setSuccess(success);
-        deserializeWriteResponse(in, result);
+        deserializeWriteResponse(in, result, serialVersion);
         return result;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/GetRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/GetRequestSerializer.java
@@ -7,6 +7,9 @@
 
 package oracle.nosql.driver.ops.serde;
 
+import static oracle.nosql.driver.util.BinaryProtocol.V2;
+import static oracle.nosql.driver.util.BinaryProtocol.V3;
+
 import java.io.IOException;
 
 import oracle.nosql.driver.ops.GetRequest;
@@ -39,11 +42,17 @@ class GetRequestSerializer extends BinaryProtocol implements Serializer {
 
         GetResult result = new GetResult();
         deserializeConsumedCapacity(in, result);
+        if (serialVersion < V3) {
+            result.setModificationTime(-1);
+        }
         boolean hasRow = in.readBoolean();
         if (hasRow) {
             result.setValue(readFieldValue(in).asMap());
             result.setExpirationTime(readLong(in));
             result.setVersion(readVersion(in));
+            if (serialVersion > V2) {
+                result.setModificationTime(readLong(in));
+            }
         }
         return result;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/GetTableRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/GetTableRequestSerializer.java
@@ -38,7 +38,7 @@ class GetTableRequestSerializer extends BinaryProtocol implements Serializer {
                                    short serialVersion)
         throws IOException {
 
-        return deserializeTableResult(in);
+        return deserializeTableResult(in, serialVersion);
     }
 
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/MultiDeleteRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/MultiDeleteRequestSerializer.java
@@ -29,6 +29,7 @@ class MultiDeleteRequestSerializer extends BinaryProtocol
         writeOpCode(out, OpCode.MULTI_DELETE);
         serializeRequest(mdRq, out);
         writeString(out, mdRq.getTableName());
+        writeDurability(out, mdRq.getDurability(), serialVersion);
         writeFieldValue(out, mdRq.getKey());
         writeFieldRange(out, mdRq.getRange());
         writeInt(out, mdRq.getMaxWriteKB());

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/PutRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/PutRequestSerializer.java
@@ -49,7 +49,7 @@ class PutRequestSerializer extends BinaryProtocol implements Serializer {
         if (isSubRequest) {
             out.writeBoolean(putRq.getReturnRow());
         } else {
-            serializeWriteRequest(putRq, out);
+            serializeWriteRequest(putRq, out, serialVersion);
         }
         out.writeBoolean(putRq.getExactMatch());
         writeInt(out, putRq.getIdentityCacheSize());
@@ -76,7 +76,7 @@ class PutRequestSerializer extends BinaryProtocol implements Serializer {
         }
 
         /* return row info */
-        deserializeWriteResponse(in, result);
+        deserializeWriteResponse(in, result, serialVersion);
 
         /* generated identity column value */
         deserializeGeneratedValue(in, result);

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/TableRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/TableRequestSerializer.java
@@ -38,6 +38,7 @@ class TableRequestSerializer extends BinaryProtocol implements Serializer {
             out.writeInt(limits.getReadUnits());
             out.writeInt(limits.getWriteUnits());
             out.writeInt(limits.getStorageGB());
+            writeCapacityMode(out, limits.getMode(), serialVersion);
             if (rq.getTableName() != null) {
                 /* table name may exist with limits */
                 out.writeBoolean(true);
@@ -56,6 +57,6 @@ class TableRequestSerializer extends BinaryProtocol implements Serializer {
                                    short serialVersion)
         throws IOException {
 
-        return deserializeTableResult(in);
+        return deserializeTableResult(in, serialVersion);
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/WriteMultipleRequestSerialier.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/WriteMultipleRequestSerialier.java
@@ -52,6 +52,9 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         /* The number of operations */
         writeInt(out, num);
 
+        /* Durability setting */
+        writeDurability(out, umRq.getDurability(), serialVersion);
+
         /* Operations */
         for (OperationRequest op : umRq.getOperations()) {
             int start = out.getOffset();
@@ -86,16 +89,17 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         if (succeed) {
             int num = readInt(in);
             for (int i = 0; i < num; i++) {
-                umResult.addResult(createOperationResult(in));
+                umResult.addResult(createOperationResult(in, serialVersion));
             }
         } else {
             umResult.setFailedOperationIndex(in.readByte());
-            umResult.addResult(createOperationResult(in));
+            umResult.addResult(createOperationResult(in, serialVersion));
         }
         return umResult;
     }
 
-    private OperationResult createOperationResult(ByteInputStream in)
+    private OperationResult createOperationResult(ByteInputStream in,
+                                                  short serialVersion)
         throws IOException {
 
         OperationResult opResult = new OperationResult();
@@ -112,7 +116,7 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         }
 
         /* Previous value and version */
-        deserializeWriteResponse(in, opResult);
+        deserializeWriteResponse(in, opResult, serialVersion);
 
         /* Generated value, if present */
         boolean hasGeneratedValue = in.readBoolean();

--- a/driver/src/main/java/oracle/nosql/driver/util/BinaryProtocol.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/BinaryProtocol.java
@@ -16,10 +16,16 @@ public final class BinaryProtocol {
 
     public static final short QUERY_V1 = 1;
 
+    public static final short V2 = 2;
+
+    public static final short V3 = 3;
+
     /**
-     * Serial version of the protocol
+     * Default serial version of the protocol.
+     * Note the actual version used may be less if the
+     * driver is connected to an older proxy.
      */
-    public static final short SERIAL_VERSION = 2;
+    public static final short DEFAULT_SERIAL_VERSION = V3;
 
     /**
      * Serial version of the sub-protocol related to queries
@@ -87,6 +93,20 @@ public final class BinaryProtocol {
     public static final int EVENTUAL = 1;
 
     /**
+     * Durability.
+     * note 1-offset is to distinguish between 0 (not set)
+     * and a purposefully set value
+     */
+    /* sync policy */
+    public static final int DURABILITY_SYNC = 1;
+    public static final int DURABILITY_NO_SYNC = 2;
+    public static final int DURABILITY_WRITE_NO_SYNC = 3;
+    /* ack policy */
+    public static final int DURABILITY_ALL = 1;
+    public static final int DURABILITY_NONE = 2;
+    public static final int DURABILITY_SIMPLE_MAJORITY = 3;
+
+    /**
      * Table state
      */
     public static final int ACTIVE = 0;
@@ -94,6 +114,12 @@ public final class BinaryProtocol {
     public static final int DROPPED = 2;
     public static final int DROPPING = 3;
     public static final int UPDATING = 4;
+
+    /**
+     * Table Limits mode
+     */
+    public static final int PROVISIONED = 1;
+    public static final int ON_DEMAND = 2;
 
     /**
      * Operation state
@@ -145,6 +171,10 @@ public final class BinaryProtocol {
     public static final int TENANT_DEPLOYMENT_LIMIT_EXCEEDED = 20;
     /* added in V2 */
     public static final int OPERATION_NOT_SUPPORTED = 21;
+    public static final int ETAG_MISMATCH = 22;
+    public static final int CANNOT_CANCEL_WORK_REQUEST = 23;
+    /* added in V3 */
+    public static final int UNSUPPORTED_PROTOCOL = 24;
 
     /*
      * Error codes for user throttling, range from 50 to 100(exclusive).

--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -32,6 +32,8 @@ import java.util.concurrent.Future;
 
 import org.junit.Test;
 
+import oracle.nosql.driver.Durability;
+import oracle.nosql.driver.http.NoSQLHandleImpl;
 import oracle.nosql.driver.ops.DeleteRequest;
 import oracle.nosql.driver.ops.DeleteResult;
 import oracle.nosql.driver.ops.GetIndexesRequest;
@@ -50,6 +52,7 @@ import oracle.nosql.driver.ops.PutResult;
 import oracle.nosql.driver.ops.QueryRequest;
 import oracle.nosql.driver.ops.QueryResult;
 import oracle.nosql.driver.ops.TableLimits;
+import oracle.nosql.driver.ops.TableLimits.CapacityMode;
 import oracle.nosql.driver.ops.TableResult;
 import oracle.nosql.driver.ops.TableUsageRequest;
 import oracle.nosql.driver.ops.TableUsageResult;
@@ -92,7 +95,7 @@ public class BasicTest extends ProxyTestBase {
                                       null);
                 fail("operation should have thrown");
             } catch (TableNotFoundException tnfe) {
-                // success
+                /* success */
             }
 
 
@@ -164,13 +167,13 @@ public class BasicTest extends ProxyTestBase {
             value.put("id", 20);
             putRequest.setReturnRow(true);
             PutResult pr = handle.put(putRequest);
-            assertNotNull(pr.getVersion()); // success
+            assertNotNull(pr.getVersion()); /* success */
             assertNull(pr.getExistingVersion());
             assertNull(pr.getExistingValue());
 
             putRequest.setOption(Option.IfAbsent);
             pr = handle.put(putRequest);
-            assertNull(pr.getVersion()); // failure
+            assertNull(pr.getVersion()); /* failure */
             assertNotNull(pr.getExistingVersion());
             assertNotNull(pr.getExistingValue());
 
@@ -206,7 +209,7 @@ public class BasicTest extends ProxyTestBase {
                 res1 = handle.get(getRequest);
                 fail("Attempt to access missing table should have thrown");
             } catch (TableNotFoundException nse) {
-                // success
+                /* success */
             }
 
             /* PUT -- invalid row -- this will throw */
@@ -216,7 +219,7 @@ public class BasicTest extends ProxyTestBase {
                 res = handle.put(putRequest);
                 fail("Attempt to put invalid row should have thrown");
             } catch (IllegalArgumentException iae) {
-                // success
+                /* success */
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -304,8 +307,8 @@ public class BasicTest extends ProxyTestBase {
         try {
             NoSQLHandleConfig config = new NoSQLHandleConfig(url);
             configAuth(config);
-            myhandle = getHandle(config);
             try {
+                myhandle = getHandle(config);
                 PutRequest putRequest = new PutRequest()
                     .setValue(new MapValue().put("id", 1))
                     .setTableName("testusers");
@@ -313,7 +316,7 @@ public class BasicTest extends ProxyTestBase {
                 myhandle.put(putRequest);
                 fail("Operation should have failed");
             } catch (Exception e) {
-                // success
+                /* success */
             }
         } catch (Exception e) {
             fail("?: " + e);
@@ -540,21 +543,35 @@ public class BasicTest extends ProxyTestBase {
         final String tableName = "testusers";
         final int recordKB = 2;
 
+        final short serialVersion =
+              ((NoSQLHandleImpl)handle).getSerialVersion();
+
+        final String stmt = "create table if not exists testusers(id " +
+                            "integer, name string, primary key(id))";
         /* Create a table */
-        TableResult tres = tableOperation(
-            handle,
-            "create table if not exists testusers(id integer, " +
-            "name string, primary key(id))",
-            new TableLimits(500, 500, 50));
-        assertEquals(TableResult.State.ACTIVE, tres.getTableState());
+        try {
+            TableResult tres = tableOperation(handle, stmt,
+                new TableLimits(0, 0, 50, CapacityMode.ON_DEMAND));
+            assertEquals(TableResult.State.ACTIVE, tres.getTableState());
+        } catch (IllegalArgumentException iae) {
+            /* expected in V2 */
+            if (serialVersion > 2) {
+                throw iae;
+            }
+            TableResult tres = tableOperation(handle, stmt,
+                new TableLimits(500, 500, 50, CapacityMode.PROVISIONED));
+            assertEquals(TableResult.State.ACTIVE, tres.getTableState());
+        }
 
         final String name = genString((recordKB - 1) * 1024);
         MapValue value = new MapValue().put("id", 10).put("name", name);
         MapValue newValue = new MapValue().put("id", 11).put("name", name);
 
+
         /* Put a row */
         PutRequest putReq = new PutRequest()
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         PutResult putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -562,6 +579,7 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
 
         /*
@@ -575,6 +593,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent */,
                        null /* expPrevValue */,
                        null /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         Version oldVersion = putRes.getVersion();
 
@@ -582,6 +601,7 @@ public class BasicTest extends ProxyTestBase {
         putReq = new PutRequest()
             .setOption(Option.IfAbsent)
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -589,6 +609,7 @@ public class BasicTest extends ProxyTestBase {
                        true  /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         /*
          * PutIfAbsent fails + SetReturnRow(true),
@@ -601,12 +622,14 @@ public class BasicTest extends ProxyTestBase {
                        true  /* rowPresent */,
                        value /* expPrevValue */,
                        oldVersion /* expPrevVersion */,
+                       (serialVersion > 2), /* modtime should be recent */
                        recordKB);
 
         /* PutIfPresent an existing row, it should succeed */
         putReq = new PutRequest()
             .setOption(Option.IfPresent)
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -614,6 +637,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent */,
                        null /* expPrevValue */,
                        null /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         /*
          * PutIfPresent succeed + SetReturnRow(true),
@@ -626,6 +650,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent */,
                        null /* expPrevValue */,
                        null /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         Version ifVersion = putRes.getVersion();
 
@@ -633,6 +658,7 @@ public class BasicTest extends ProxyTestBase {
         putReq = new PutRequest()
             .setOption(Option.IfPresent)
             .setValue(newValue)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -640,6 +666,7 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         /*
          * PutIfPresent fail + SetReturnRow(true),
@@ -652,12 +679,14 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
 
         /* PutIfAbsent an new row, it should succeed */
         putReq = new PutRequest()
             .setOption(Option.IfAbsent)
             .setValue(newValue)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -665,6 +694,7 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
 
         /*
@@ -674,6 +704,7 @@ public class BasicTest extends ProxyTestBase {
             .setOption(Option.IfVersion)
             .setMatchVersion(oldVersion)
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -681,6 +712,7 @@ public class BasicTest extends ProxyTestBase {
                        true  /* rowPresent */,
                        null  /* expPrevValue */,
                        null  /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         /*
          * PutIfVersion fails + SetReturnRow(true),
@@ -693,6 +725,7 @@ public class BasicTest extends ProxyTestBase {
                        true  /* rowPresent */,
                        value /* expPrevValue */,
                        ifVersion /* expPrevVersion */,
+                       (serialVersion > 2), /* modtime should be recent */
                        recordKB);
 
         /*
@@ -702,6 +735,7 @@ public class BasicTest extends ProxyTestBase {
             .setOption(Option.IfVersion)
             .setMatchVersion(ifVersion)
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         putRes = handle.put(putReq);
         checkPutResult(putReq, putRes,
@@ -709,6 +743,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent */,
                        null /* expPrevValue */,
                        null /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         ifVersion = putRes.getVersion();
         /*
@@ -722,6 +757,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent */,
                        null /* expPrevValue */,
                        null /* expPrevVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
         Version newVersion = putRes.getVersion();
 
@@ -732,6 +768,7 @@ public class BasicTest extends ProxyTestBase {
         putReq = new PutRequest()
             .setOption(Option.IfVersion)
             .setValue(value)
+            .setDurability(Durability.COMMIT_SYNC)
             .setTableName(tableName);
         try {
             putRes = handle.put(putReq);
@@ -753,6 +790,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent*/,
                        value,
                        null, /* Don't check version if Consistency.EVENTUAL */
+                       (serialVersion > 2), /* modtime should be recent */
                        recordKB);
 
         /* Get a row with ABSOLUTE consistency */
@@ -762,6 +800,7 @@ public class BasicTest extends ProxyTestBase {
                        true /* rowPresent*/,
                        value,
                        newVersion,
+                       (serialVersion > 2), /* modtime should be recent */
                        recordKB);
 
         /* Get non-existing row */
@@ -774,6 +813,7 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent*/,
                        null  /* expValue */,
                        null  /* expVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
 
         /* Get a row with ABSOLUTE consistency */
@@ -783,6 +823,7 @@ public class BasicTest extends ProxyTestBase {
                        false /* rowPresent*/,
                        null  /* expValue */,
                        null  /* expVersion */,
+                       false, /* modtime should be zero */
                        recordKB);
 
         /* Delete a row */
@@ -796,6 +837,7 @@ public class BasicTest extends ProxyTestBase {
                           true  /* rowPresent */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /* Put the row back to store */
@@ -810,6 +852,7 @@ public class BasicTest extends ProxyTestBase {
                           true /* rowPresent */,
                           null /* expPrevValue */,
                           null /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /* Delete fail + setReturnRow(true), no existing row returned. */
@@ -819,6 +862,7 @@ public class BasicTest extends ProxyTestBase {
                           false /* rowPresent */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /* Put the row back to store */
@@ -837,6 +881,7 @@ public class BasicTest extends ProxyTestBase {
                           true  /* rowPresent */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /*
@@ -850,6 +895,7 @@ public class BasicTest extends ProxyTestBase {
                           true  /* rowPresent */,
                           value /* expPrevValue */,
                           ifVersion /* expPrevVersion */,
+                          (serialVersion > 2), /* modtime should be recent */
                           recordKB);
 
         /* DeleteIfVersion with matched version, it should succeed. */
@@ -863,6 +909,7 @@ public class BasicTest extends ProxyTestBase {
                           true  /* rowPresent */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /* Put the row back to store */
@@ -881,6 +928,7 @@ public class BasicTest extends ProxyTestBase {
                           true  /* returnRow */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
 
         /* DeleteIfVersion with a key not existed, it should fail. */
@@ -894,6 +942,7 @@ public class BasicTest extends ProxyTestBase {
                           false /* returnRow */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
         /*
          * DeleteIfVersion with a key not existed + setReturnRow(true),
@@ -906,6 +955,7 @@ public class BasicTest extends ProxyTestBase {
                           false /* returnRow */,
                           null  /* expPrevValue */,
                           null  /* expPrevVersion */,
+                          false, /* modtime should be zero */
                           recordKB);
     }
 
@@ -1203,7 +1253,7 @@ public class BasicTest extends ProxyTestBase {
             putRet = handle.put(putReq);
             fail("Put should have thrown IAE");
         } catch (Exception e) {
-            // success
+            /* success */
         }
 
         /* test via query insert */
@@ -1292,7 +1342,7 @@ public class BasicTest extends ProxyTestBase {
             putRet = handle.put(putReq);
             fail("Exception should have been thrown on put");
         } catch (Exception e) {
-            // success
+            /* success */
         }
 
         /* try an insert query */
@@ -1321,12 +1371,12 @@ public class BasicTest extends ProxyTestBase {
         try {
             doLargeRow(handle, false);
         } catch (Exception e) {
-            // success
+            /* success */
         }
         try {
             doLargeRow(handle, true);
         } catch (Exception e) {
-            // success
+            /* success */
         }
     }
 
@@ -1391,12 +1441,25 @@ public class BasicTest extends ProxyTestBase {
         }
     }
 
+    private void checkModTime(long modTime, boolean modTimeRecent) {
+        if (modTimeRecent) {
+            if (modTime < (System.currentTimeMillis() - 2000)) {
+                fail("Expected modtime to be recent, got " + modTime);
+            }
+        } else {
+            if (modTime != 0) {
+                fail("Expected modtime to be zero, got " + modTime);
+            }
+        }
+    }
+
     private void checkPutResult(PutRequest request,
                                 PutResult result,
                                 boolean shouldSucceed,
                                 boolean rowPresent,
                                 MapValue expPrevValue,
                                 Version expPrevVersion,
+                                boolean modTimeRecent,
                                 int recordKB) {
         if (shouldSucceed) {
             assertNotNull("Put should succeed", result.getVersion());
@@ -1405,6 +1468,8 @@ public class BasicTest extends ProxyTestBase {
         }
         checkExistingValueVersion(request, result, shouldSucceed, rowPresent,
                                   expPrevValue, expPrevVersion);
+
+        checkModTime(result.getExistingModificationTime(), modTimeRecent);
     }
 
     private void checkDeleteResult(DeleteRequest request,
@@ -1413,12 +1478,14 @@ public class BasicTest extends ProxyTestBase {
                                    boolean rowPresent,
                                    MapValue expPrevValue,
                                    Version expPrevVersion,
+                                   boolean modTimeRecent,
                                    int recordKB) {
 
         assertEquals("Delete should " + (shouldSucceed ? "succeed" : " fail"),
                      shouldSucceed, result.getSuccess());
         checkExistingValueVersion(request, result, shouldSucceed, rowPresent,
                                   expPrevValue, expPrevVersion);
+        checkModTime(result.getExistingModificationTime(), modTimeRecent);
     }
 
     private void checkGetResult(GetRequest request,
@@ -1426,6 +1493,7 @@ public class BasicTest extends ProxyTestBase {
                                 boolean rowPresent,
                                 MapValue expValue,
                                 Version expVersion,
+                                boolean modTimeRecent,
                                 int recordKB) {
 
 
@@ -1446,6 +1514,7 @@ public class BasicTest extends ProxyTestBase {
             assertNull("Unexpected value", expValue);
             assertNull("Unexpected version", result.getVersion());
         }
+        checkModTime(result.getModificationTime(), modTimeRecent);
     }
 
     private void checkExistingValueVersion(WriteRequest request,

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -364,14 +364,23 @@ public class ProxyTestBase {
         /* allow test cases to add/modify handle config */
         perTestHandleConfig(config);
 
-        return getHandle(config);
+        NoSQLHandle h = getHandle(config);
+
+        /* this will set up the right protocol serial version */
+        try {
+            getTable("noop", h);
+        } catch (Exception e) {
+            /* ignore errors */
+        }
+
+        return h;
     }
 
     /**
      * sub classes can override this to affect the handle config
      */
     protected void perTestHandleConfig(NoSQLHandleConfig config) {
-        // no-op
+        /* no-op */
     }
 
     /**
@@ -379,11 +388,14 @@ public class ProxyTestBase {
      */
     protected NoSQLHandle getHandle(NoSQLHandleConfig config) {
         /*
-         * Create a Logger, set to WARNING. TODO: use a property
-         * for level.
+         * Create a Logger, set to WARNING by default.
          */
         Logger logger = Logger.getLogger(getClass().getName());
-        logger.setLevel(Level.WARNING);
+        String level = System.getProperty("test.loglevel");
+        if (level == null) {
+            level = "WARNING";
+        }
+        logger.setLevel(Level.parse(level));
         config.setLogger(logger);
 
         /*


### PR DESCRIPTION
Added:
- Cloud only: Support for On-Demand tables in TableLimits
- Row modification time made available in GetResult
- Existing row modification time made available in PutResult and DeleteResult when operation fails and previous value is requested
- On-Prem only: Support for setting Durability in write operations (put/delete/writeMultiple/multiDelete)

Changed:
- Internally, the SDK now detects the serial version of the server it's connected to, and adjusts its capabilities to match. If the server is an older version, and some features may not be available, client apps may get a one-time log message (at INFO level) with text like "The requested feature is not supported by the connected server".