### PR TITLE
Fixed a case where received messages may not be released properly

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
+++ b/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
@@ -7,6 +7,8 @@
 
 package oracle.nosql.driver.httpclient;
 
+import static oracle.nosql.driver.util.LogUtil.isFineEnabled;
+import static oracle.nosql.driver.util.LogUtil.logFine;
 import static oracle.nosql.driver.util.LogUtil.logInfo;
 import static oracle.nosql.driver.util.LogUtil.logWarning;
 
@@ -309,6 +311,18 @@ public class HttpClient {
              * Ensure that the channel is in good shape
              */
             if (fut.isSuccess() && retChan.isActive()) {
+                /*
+                 * Clear out any previous state. The channel should not
+                 * have any state associated with it, but this code is here
+                 * just in case it does.
+                 */
+                if (retChan.attr(STATE_KEY).get() != null) {
+                    if (isFineEnabled(logger)) {
+                        logFine(logger, "HttpClient acquired a channel with " +
+                                "a still-active state: clearing.");
+                    }
+                    retChan.attr(STATE_KEY).set(null);
+                }
                 return retChan;
             }
             logInfo(logger,
@@ -319,6 +333,9 @@ public class HttpClient {
     }
 
     public void releaseChannel(Channel channel) {
+        /* Clear any response handler state from channel before releasing it */
+        channel.attr(STATE_KEY).set(null);
+
         /*
          * If channel is not healthy/active it will be closed and removed
          * from the pool. Don't wait for completion.


### PR DESCRIPTION
Fixed a case where received messages may not be released properly if a lot of requests are timing out before their responses are received. This can happen when the netty channel thread receives an older response while a current response is being processed by a driver thread.
The fix is to make sure the channel's state attribute is cleared as soon as the channel handler receives a valid response and notifies the driver thread. The state is also cleared when the driver thread releases the channel.