### PR TITLE
Added logic to manage versions of proxy, kvclient, and kvserver.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -152,14 +152,6 @@ public class Client {
      */
     private ExecutorService threadPool;
 
-    /*
-     * Version strings for connected proxy and store
-     * Used mainly for tests
-     */
-    private String proxyVersion;
-    private String KVClientVersion;
-    private String KVServerVersion;
-
     /**
      * config for statistics
      */
@@ -535,8 +527,6 @@ public class Client {
                     logTrace(logger, "Response: " + requestClass + ", status " +
                              responseHandler.getStatus());
                 }
-
-                processVersionHeader(responseHandler.getHeaders());
 
                 ByteBuf wireContent = responseHandler.getContent();
                 Result res = processResponse(responseHandler.getStatus(),
@@ -1174,80 +1164,6 @@ public class Client {
             }
         }
     }
-
-    /**
-     * Get the proxy and kv versions from the response header.
-     * Update local values if different.
-     */
-    private void processVersionHeader(HttpHeaders headers) {
-        if (headers == null) {
-            return;
-        }
-        String versions = headers.get(PROXY_VERSION_HEADER);
-        if (versions == null) {
-            return;
-        }
-        /* versions string is space-separated k=v pairs */
-        String[] kvs = versions.split(" ");
-        if (kvs == null || kvs.length == 0) {
-            return;
-        }
-        for (int x=0; x<kvs.length; x++) {
-            String[] kv = kvs[x].split("=");
-            if (kv == null || kv.length != 2) {
-                continue;
-            }
-            if (kv[0].compareTo("proxy")==0) {
-                if (proxyVersion == null ||
-                    proxyVersion.compareTo(kv[1]) != 0) {
-                    proxyVersion = kv[1];
-                }
-            } else if (kv[0].compareTo("kv")==0 ||
-                       kv[0].compareTo("client")==0) {
-                if (KVClientVersion == null ||
-                    KVClientVersion.compareTo(kv[1]) != 0) {
-                    KVClientVersion = kv[1];
-                }
-            } else if (kv[0].compareTo("server")==0) {
-                /* note: not yet implemented in proxy */
-                if (KVServerVersion == null ||
-                    KVServerVersion.compareTo(kv[1]) != 0) {
-                    KVServerVersion = kv[1];
-                }
-            }
-        }
-    }
-
-    /**
-     * Get the current KV client version used by the proxy.
-     * For testing use.
-     * The version is a string in X.Y.Z format, like "21.3.14".
-     * @return version, or null of not returned in proxy headers
-     */
-    public String getKVClientVersion() {
-        return KVClientVersion;
-    }
-
-    /**
-     * Get the current KV server version used through the proxy.
-     * For testing use.
-     * The version is a string in X.Y.Z format, like "21.3.14".
-     * @return version, or null of not returned in proxy headers
-     */
-    public String getKVServerVersion() {
-        return KVServerVersion;
-    }
-
-    /**
-     * Get the current proxy version.
-     * For testing use.
-     * The version is a string in X.Y.Z format, like "21.3.14".
-     * @return version, or null of not returned in proxy headers
-     */
-    public String getProxyVersion() {
-        return proxyVersion;
-    }
-
 
     /**
      * Returns the statistics control object.

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
@@ -95,6 +95,11 @@ public class HttpConstants {
     public static final String USER_AGENT = "User-Agent";
 
     /*
+     * NoSQL versions header
+     */
+    public static final String PROXY_VERSION_HEADER = "x-nosql-version";
+
+    /*
      * Content type values
      */
     public static final String APPLICATION_JSON =

--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -449,7 +449,7 @@ public class BasicTest extends ProxyTestBase {
             tres = tableOperation(handle, DROP_TABLE, null);
         } catch (TableNotFoundException e) {
             /* versions before 20.3 had known issues with drop table */
-            if (checkKVVersion(handle, 20, 3, 1)) {
+            if (checkKVVersion(20, 3, 1)) {
                 throw e;
             }
         }
@@ -1344,7 +1344,7 @@ public class BasicTest extends ProxyTestBase {
      */
     @Test
     public void testFlexibleMapping() throws Exception {
-        assumeKVVersion(handle, "testFlexibleMapping", 20, 2, 1);
+        assumeKVVersion("testFlexibleMapping", 20, 2, 1);
         final String createTable =
             "create table flex(id integer, primary key(id), " +
             "str string, " +

--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -445,9 +445,14 @@ public class BasicTest extends ProxyTestBase {
         PutResult pres = handle.put(pr);
         assertNotNull(pres.getVersion());
 
-        tres = tableOperation(handle,
-                              DROP_TABLE,
-                              null);
+        try {
+            tres = tableOperation(handle, DROP_TABLE, null);
+        } catch (TableNotFoundException e) {
+            /* versions before 20.3 had known issues with drop table */
+            if (checkKVVersion(handle, 20, 3, 1)) {
+                throw e;
+            }
+        }
 
         tres = tableOperation(handle,
                               CREATE_TABLE,
@@ -1339,6 +1344,7 @@ public class BasicTest extends ProxyTestBase {
      */
     @Test
     public void testFlexibleMapping() throws Exception {
+        assumeKVVersion(handle, "testFlexibleMapping", 20, 2, 1);
         final String createTable =
             "create table flex(id integer, primary key(id), " +
             "str string, " +

--- a/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
@@ -146,6 +146,9 @@ public class OnPremiseTest extends ProxyTestBase {
       }
     */
     protected void dropRegions(NoSQLHandle nosqlHandle) {
+        if (checkKVVersion(nosqlHandle, 20, 1, 1) == false) {
+            return;
+        }
         SystemResult res = doSysOp(nosqlHandle, "show as json regions");
         String regionString = res.getResultString();
         if (regionString != null) {
@@ -234,7 +237,7 @@ public class OnPremiseTest extends ProxyTestBase {
     @Test
     public void testChildTables()
         throws Exception {
-
+        assumeKVVersion(handle, "testChildTable", 20, 1, 1);
         String tableName = "parent";
         String createTableStatement =
             "CREATE TABLE IF NOT EXISTS " + tableName +
@@ -568,6 +571,7 @@ public class OnPremiseTest extends ProxyTestBase {
 
     @Test
     public void testLargeRow() {
+        assumeKVVersion(handle, "testLargeRow", 20, 1, 1);
         doLargeRow(handle, true);
     }
 
@@ -576,6 +580,7 @@ public class OnPremiseTest extends ProxyTestBase {
      */
     @Test
     public void testMultiRegion() {
+        assumeKVVersion(handle, "testMultiRegion", 20, 1, 1);
         final String show = "show regions";
         final String createRegion = "create region remoteRegion";
         final String setRegion = "set local region localRegion";

--- a/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
@@ -146,7 +146,7 @@ public class OnPremiseTest extends ProxyTestBase {
       }
     */
     protected void dropRegions(NoSQLHandle nosqlHandle) {
-        if (checkKVVersion(nosqlHandle, 20, 1, 1) == false) {
+        if (checkKVVersion(20, 1, 1) == false) {
             return;
         }
         SystemResult res = doSysOp(nosqlHandle, "show as json regions");
@@ -237,7 +237,7 @@ public class OnPremiseTest extends ProxyTestBase {
     @Test
     public void testChildTables()
         throws Exception {
-        assumeKVVersion(handle, "testChildTable", 20, 1, 1);
+        assumeKVVersion("testChildTable", 20, 1, 1);
         String tableName = "parent";
         String createTableStatement =
             "CREATE TABLE IF NOT EXISTS " + tableName +
@@ -571,7 +571,7 @@ public class OnPremiseTest extends ProxyTestBase {
 
     @Test
     public void testLargeRow() {
-        assumeKVVersion(handle, "testLargeRow", 20, 1, 1);
+        assumeKVVersion("testLargeRow", 20, 1, 1);
         doLargeRow(handle, true);
     }
 
@@ -580,7 +580,7 @@ public class OnPremiseTest extends ProxyTestBase {
      */
     @Test
     public void testMultiRegion() {
-        assumeKVVersion(handle, "testMultiRegion", 20, 1, 1);
+        assumeKVVersion("testMultiRegion", 20, 1, 1);
         final String show = "show regions";
         final String createRegion = "create region remoteRegion";
         final String setRegion = "set local region localRegion";

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -78,6 +78,18 @@ public class ProxyTestBase {
     protected static int DEFAULT_DML_TIMEOUT = 5000;
     protected static String TEST_TABLE_NAME = "drivertest";
 
+    protected static String PROXY_VERSION_PROP = "test.proxy.version";
+    protected static String KVCLIENT_VERSION_PROP = "test.kv.client.version";
+    protected static String KVSERVER_VERSION_PROP = "test.kv.server.version";
+    protected static String PROXY_VERSION_ENV = "PROXY_VERSION";
+    protected static String KVCLIENT_VERSION_ENV = "KV_CLIENT_VERSION";
+    protected static String KVSERVER_VERSION_ENV = "KV_SERVER_VERSION";
+
+    /* (major * 1M) + (minor * 1K) + patch */
+    protected static int proxyVersion;
+    protected static int kvClientVersion;
+    protected static int kvServerVersion;
+
     protected static String serverType;
     protected static String endpoint;
     protected static boolean verbose;
@@ -132,6 +144,20 @@ public class ProxyTestBase {
         verbose = Boolean.getBoolean(VERBOSE);
         local = Boolean.getBoolean(LOCAL);
         trace = Boolean.getBoolean(TRACE);
+
+        proxyVersion = intVersion(System.getProperty(PROXY_VERSION_PROP));
+        if (proxyVersion <= 0) {
+            proxyVersion = intVersion(System.getenv(PROXY_VERSION_ENV));
+        }
+        kvClientVersion = intVersion(System.getProperty(KVCLIENT_VERSION_PROP));
+        if (kvClientVersion <= 0) {
+            kvClientVersion = intVersion(System.getenv(KVCLIENT_VERSION_ENV));
+        }
+        kvServerVersion = intVersion(System.getProperty(KVSERVER_VERSION_PROP));
+        if (kvServerVersion <= 0) {
+            kvServerVersion = intVersion(System.getenv(KVSERVER_VERSION_ENV));
+        }
+
         /* these features are not yet available in the cloud */
         uuidSupported = onprem;
         arrayAsRecordSupported = onprem;
@@ -287,7 +313,7 @@ public class ProxyTestBase {
                 droppedTables.add(tres);
             } catch (TableNotFoundException tnfe) {
                 /* this is expected in 20.X and older */
-                if (checkKVVersion(nosqlHandle, 21, 1, 1)) {
+                if (checkKVVersion(21, 1, 1)) {
                     System.err.println("DropAllTables: drop fail, table "
                                        + tableName + ": " + tnfe);
                 }
@@ -316,7 +342,7 @@ public class ProxyTestBase {
                 tres.waitForCompletion(nosqlHandle, 30000, 300);
             } catch (TableNotFoundException tnfe) {
                 /* this is expected in 20.X and older */
-                if (checkKVVersion(nosqlHandle, 21, 1, 1)) {
+                if (checkKVVersion(21, 1, 1)) {
                     System.err.println("DropAllTables: drop wait fail, table "
                                        + tres + ": " + tnfe);
                 }
@@ -342,7 +368,7 @@ public class ProxyTestBase {
             tres.waitForCompletion(nosqlHandle, 20000, 1000);
         } catch (TableNotFoundException e) {
             /* 20.2 and below have a known issue with drop table */
-            if (checkKVVersion(nosqlHandle, 20, 3, 1) == true) {
+            if (checkKVVersion(20, 3, 1) == true) {
                 throw e;
             }
         }
@@ -388,7 +414,6 @@ public class ProxyTestBase {
         NoSQLHandle h = getHandle(config);
 
         /* this will set up the right protocol serial version */
-        /* and get the proxy/kv versions into the client */
         try {
             getTable("noop", h);
         } catch (Exception e) {
@@ -582,7 +607,7 @@ public class ProxyTestBase {
      * integer value of (X * 1M) + (Y * 1K) + Z
      * return -1 if the string isn't in valid X.Y.Z format
      */
-    protected static int getIntegerVersion(String version) {
+    protected static int intVersion(String version) {
         if (version == null || version.length() < 5) {
             return -1;
         }
@@ -598,95 +623,61 @@ public class ProxyTestBase {
         return -1;
     }
 
-    protected static String getKVServerVersion(NoSQLHandle handle) {
-        /*
-         * Use the value returned from the proxy. If that doesn't
-         * exist, fall back to an environment setting.
-         * Note: currently, the proxy will not return this value. So the
-         * environment setting will always be used.
-         */
-        String kvver =
-                   ((NoSQLHandleImpl)handle).getClient().getKVServerVersion();
-        if (getIntegerVersion(kvver) > 0) {
-            return kvver;
+    /*
+     * Inverse of above, for messages
+     */
+    protected static String stringVersion(int ver) {
+        if (ver <= 0) {
+            return "unknown";
         }
-        return System.getenv("KV_SERVER_VERSION");
+        return (ver / 1000000) + "." +
+               ((ver / 1000) % 1000) + "." +
+               (ver % 1000);
     }
 
-    protected static String getKVClientVersion(NoSQLHandle handle) {
+    private static int getMinimumKVVersion() {
         /*
-         * Use the value returned from the proxy. If that doesn't
-         * exist, fall back to an environment setting.
-         */
-        String kvver =
-                   ((NoSQLHandleImpl)handle).getClient().getKVClientVersion();
-        if (getIntegerVersion(kvver) > 0) {
-            return kvver;
-        }
-        return System.getenv("KV_CLIENT_VERSION");
-    }
-
-    protected static String getProxyVersion(NoSQLHandle handle) {
-        /*
-         * Use the value returned from the proxy. If that doesn't
-         * exist, fall back to an environment setting.
-         */
-        String proxyver =
-                   ((NoSQLHandleImpl)handle).getClient().getProxyVersion();
-        if (getIntegerVersion(proxyver) > 0) {
-            return proxyver;
-        }
-        return System.getenv("PROXY_VERSION");
-    }
-
-    private static String getMinimumKVVersion(NoSQLHandle handle) {
-        /*
-         * We need to use the minumum of the kv client and server versions to
+         * Use the minumum of the kv client and server versions to
          * determine what features should be valid to test.
          */
-        String serverVer = getKVServerVersion(handle);
-        String clientVer = getKVClientVersion(handle);
-        int serverIntVer = getIntegerVersion(serverVer);
-        if (serverIntVer < 0) {
-            return clientVer;
+        if (kvServerVersion <= 0) {
+            return kvClientVersion;
+        } else if (kvClientVersion <= 0) {
+            return kvServerVersion;
         }
-        int clientIntVer = getIntegerVersion(clientVer);
-        if (clientIntVer < 0 || clientIntVer > serverIntVer) {
-            return serverVer;
+        if (kvServerVersion < kvClientVersion) {
+            return kvServerVersion;
         }
-        return clientVer;
+        return kvClientVersion;
     }
 
     /*
      * Used to skip test if run against KV prior to the specified version
      * <major>.<minor>.<patch>.
      */
-    protected static void assumeKVVersion(NoSQLHandle handle,
-                                          String test,
+    protected static void assumeKVVersion(String test,
                                           int major,
                                           int minor,
                                           int patch) {
-        if (checkKVVersion(handle, major, minor, patch)) {
+        if (checkKVVersion(major, minor, patch)) {
             return;
         }
         assumeTrue("Skipping " + test + " if run against KV prior to " +
                    (major + "." + minor + "." + patch) + ": " +
-                   getMinimumKVVersion(handle), false);
+                   stringVersion(getMinimumKVVersion()), false);
     }
 
     /*
      * Returns true if the current KV is >= version <major.minor.patch>
      */
-    public static boolean checkKVVersion(NoSQLHandle handle,
-                                         int major,
+    public static boolean checkKVVersion(int major,
                                          int minor,
                                          int patch) {
-        String minVersion = getMinimumKVVersion(handle);
-        int minIntVersion = getIntegerVersion(minVersion);
-        if (minIntVersion <= 0) {
+        int minVersion = getMinimumKVVersion();
+        if (minVersion <= 0) {
             return false; // we have no way of knowing for sure
         }
-        int desiredIntVersion = (major * 1000000) + (minor * 1000) + patch;
-        return (minIntVersion >= desiredIntVersion);
+        int desiredVersion = (major * 1000000) + (minor * 1000) + patch;
+        return (minVersion >= desiredVersion);
     }
 }

--- a/driver/src/test/java/oracle/nosql/driver/QueryTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/QueryTest.java
@@ -1014,7 +1014,7 @@ public class QueryTest extends ProxyTestBase {
 
     @Test
     public void testUpdatePrepared() {
-        assumeKVVersion(handle, "testUpdatePrepared", 21, 3, 1);
+        assumeKVVersion("testUpdatePrepared", 21, 3, 1);
         final int numMajor = 1;
         final int numPerMajor = 10;
         final int recordKB = 2;
@@ -1602,7 +1602,7 @@ public class QueryTest extends ProxyTestBase {
         assertNotNull(putRet.getVersion());
         assertNotNull(putRet.getGeneratedValue());
 
-        if (checkKVVersion(handle, 20, 3, 1) == false) {
+        if (checkKVVersion(20, 3, 1) == false) {
             return;
         }
 
@@ -1672,7 +1672,7 @@ public class QueryTest extends ProxyTestBase {
     @Test
     public void testLowThroughput() {
         if (onprem == false) {
-            assumeKVVersion(handle, "testLowThroughput", 21, 3, 1);
+            assumeKVVersion("testLowThroughput", 21, 3, 1);
         }
         final int numRows = 500;
         String name = "testThroughput";
@@ -1742,9 +1742,9 @@ public class QueryTest extends ProxyTestBase {
     @Test
     public void testLargeQueryStrings() {
         if (onprem) {
-            assumeKVVersion(handle, "testLargeQueryStrings", 20, 1, 1);
+            assumeKVVersion("testLargeQueryStrings", 20, 1, 1);
         } else {
-            assumeKVVersion(handle, "testLargeQueryStrings", 21, 3, 1);
+            assumeKVVersion("testLargeQueryStrings", 21, 3, 1);
         }
         final String tableName = "LargeQuery";
         final String createTable = "create table " + tableName +
@@ -1786,7 +1786,7 @@ public class QueryTest extends ProxyTestBase {
         if (!arrayAsRecordSupported) {
             return;
         }
-        assumeKVVersion(handle, "testBindArrayValue", 20, 3, 1);
+        assumeKVVersion("testBindArrayValue", 20, 3, 1);
         final String tableName = "testBindArrayValue";
         final String createTable = "create table if not exists " + tableName +
                 "(id integer, " +

--- a/driver/src/test/java/oracle/nosql/driver/QueryTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/QueryTest.java
@@ -7,10 +7,8 @@
 
 package oracle.nosql.driver;
 
-import static oracle.nosql.driver.util.BinaryProtocol.READ_KB_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -20,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import oracle.nosql.driver.Consistency;
-import oracle.nosql.driver.TableNotFoundException;
 import oracle.nosql.driver.ops.GetRequest;
 import oracle.nosql.driver.ops.GetResult;
 import oracle.nosql.driver.ops.PrepareRequest;
@@ -1018,6 +1014,7 @@ public class QueryTest extends ProxyTestBase {
 
     @Test
     public void testUpdatePrepared() {
+        assumeKVVersion(handle, "testUpdatePrepared", 21, 3, 1);
         final int numMajor = 1;
         final int numPerMajor = 10;
         final int recordKB = 2;
@@ -1581,7 +1578,6 @@ public class QueryTest extends ProxyTestBase {
                  "PRIMARY KEY(id))";
 
         tableOperation(handle, createTableId, new TableLimits(100, 100, 1));
-        tableOperation(handle, createTableUUID, new TableLimits(100, 100, 1));
 
         /*
          * Putting a row with a value for "id" should fail because always
@@ -1606,12 +1602,11 @@ public class QueryTest extends ProxyTestBase {
         assertNotNull(putRet.getVersion());
         assertNotNull(putRet.getGeneratedValue());
 
-        /*
-         * When the cloud supports UUID remove this
-         */
-        if (!uuidSupported) {
+        if (checkKVVersion(handle, 20, 3, 1) == false) {
             return;
         }
+
+        tableOperation(handle, createTableUUID, new TableLimits(100, 100, 1));
 
         /*
          * Now the UUID table
@@ -1676,6 +1671,9 @@ public class QueryTest extends ProxyTestBase {
 
     @Test
     public void testLowThroughput() {
+        if (onprem == false) {
+            assumeKVVersion(handle, "testLowThroughput", 21, 3, 1);
+        }
         final int numRows = 500;
         String name = "testThroughput";
         String createTableDdl =
@@ -1743,6 +1741,11 @@ public class QueryTest extends ProxyTestBase {
      */
     @Test
     public void testLargeQueryStrings() {
+        if (onprem) {
+            assumeKVVersion(handle, "testLargeQueryStrings", 20, 1, 1);
+        } else {
+            assumeKVVersion(handle, "testLargeQueryStrings", 21, 3, 1);
+        }
         final String tableName = "LargeQuery";
         final String createTable = "create table " + tableName +
             "(id integer, data json, primary key(id))";
@@ -1783,6 +1786,7 @@ public class QueryTest extends ProxyTestBase {
         if (!arrayAsRecordSupported) {
             return;
         }
+        assumeKVVersion(handle, "testBindArrayValue", 20, 3, 1);
         final String tableName = "testBindArrayValue";
         final String createTable = "create table if not exists " + tableName +
                 "(id integer, " +
@@ -1939,10 +1943,6 @@ public class QueryTest extends ProxyTestBase {
                               int recordKB,
                               Consistency consistency) {
 
-        final int minRead = 1;
-        final boolean isAbsolute = (consistency == Consistency.ABSOLUTE);
-        boolean isDelete = statement.contains("delete");
-
         final QueryRequest queryReq = new QueryRequest()
             .setStatement(statement)
             .setLimit(numLimit)
@@ -1958,7 +1958,6 @@ public class QueryTest extends ProxyTestBase {
         int writeKB = 0;
         int readUnits = 0;
         int numBatches = 0;
-        int totalPrepCost = 0;
 
         do {
             QueryResult queryRes = handle.query(queryReq);
@@ -1975,7 +1974,6 @@ public class QueryTest extends ProxyTestBase {
             int rkb = queryRes.getReadKB();
             int runits = queryRes.getReadUnits();
             int wkb = queryRes.getWriteKB();
-            int prepCost = (numBatches == 0 ? getMinQueryCost() : 0);
 
             if (showResults) {
                 for (int i = 0; i < results.size(); ++i) {
@@ -1992,7 +1990,6 @@ public class QueryTest extends ProxyTestBase {
             readKB += rkb;
             readUnits += runits;
             writeKB += wkb;
-            totalPrepCost += prepCost;
 
             numBatches++;
         } while (!queryReq.isDone());


### PR DESCRIPTION
Added logic to manage versions of proxy, kvclient, and kvserver based on the
proxy that the driver is connected to. Used for testing, to skip tests that may not
run properly against older versions. No changes to public APIs.

The logic maintains three versions: proxy, kvclient and kvserver. All versions
are first read from the reponse headers and if not there, an environment setting
is used.

Version checks in various tests are done with the minimum of client and server kv versions.
The proxy version is not checked. All three values are available to tests if needed.