### PR TITLE
Added logic to manage versions of proxy, kvclient, and kvserver.

### DIFF
--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -445,9 +445,14 @@ public class BasicTest extends ProxyTestBase {
         PutResult pres = handle.put(pr);
         assertNotNull(pres.getVersion());
 
-        tres = tableOperation(handle,
-                              DROP_TABLE,
-                              null);
+        try {
+            tres = tableOperation(handle, DROP_TABLE, null);
+        } catch (TableNotFoundException e) {
+            /* versions before 20.3 had known issues with drop table */
+            if (checkKVVersion(20, 3, 1)) {
+                throw e;
+            }
+        }
 
         tres = tableOperation(handle,
                               CREATE_TABLE,
@@ -1339,6 +1344,7 @@ public class BasicTest extends ProxyTestBase {
      */
     @Test
     public void testFlexibleMapping() throws Exception {
+        assumeKVVersion("testFlexibleMapping", 20, 2, 1);
         final String createTable =
             "create table flex(id integer, primary key(id), " +
             "str string, " +

--- a/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/OnPremiseTest.java
@@ -146,6 +146,9 @@ public class OnPremiseTest extends ProxyTestBase {
       }
     */
     protected void dropRegions(NoSQLHandle nosqlHandle) {
+        if (checkKVVersion(20, 1, 1) == false) {
+            return;
+        }
         SystemResult res = doSysOp(nosqlHandle, "show as json regions");
         String regionString = res.getResultString();
         if (regionString != null) {
@@ -234,7 +237,7 @@ public class OnPremiseTest extends ProxyTestBase {
     @Test
     public void testChildTables()
         throws Exception {
-
+        assumeKVVersion("testChildTable", 20, 1, 1);
         String tableName = "parent";
         String createTableStatement =
             "CREATE TABLE IF NOT EXISTS " + tableName +
@@ -568,6 +571,7 @@ public class OnPremiseTest extends ProxyTestBase {
 
     @Test
     public void testLargeRow() {
+        assumeKVVersion("testLargeRow", 20, 1, 1);
         doLargeRow(handle, true);
     }
 
@@ -576,6 +580,7 @@ public class OnPremiseTest extends ProxyTestBase {
      */
     @Test
     public void testMultiRegion() {
+        assumeKVVersion("testMultiRegion", 20, 1, 1);
         final String show = "show regions";
         final String createRegion = "create region remoteRegion";
         final String setRegion = "set local region localRegion";

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -24,6 +24,7 @@ package oracle.nosql.driver;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -75,6 +76,18 @@ public class ProxyTestBase {
     protected static int DEFAULT_DDL_TIMEOUT = 15000;
     protected static int DEFAULT_DML_TIMEOUT = 5000;
     protected static String TEST_TABLE_NAME = "drivertest";
+
+    protected static String PROXY_VERSION_PROP = "test.proxy.version";
+    protected static String KVCLIENT_VERSION_PROP = "test.kv.client.version";
+    protected static String KVSERVER_VERSION_PROP = "test.kv.server.version";
+    protected static String PROXY_VERSION_ENV = "PROXY_VERSION";
+    protected static String KVCLIENT_VERSION_ENV = "KV_CLIENT_VERSION";
+    protected static String KVSERVER_VERSION_ENV = "KV_SERVER_VERSION";
+
+    /* (major * 1M) + (minor * 1K) + patch */
+    protected static int proxyVersion;
+    protected static int kvClientVersion;
+    protected static int kvServerVersion;
 
     protected static String serverType;
     protected static String endpoint;
@@ -130,6 +143,20 @@ public class ProxyTestBase {
         verbose = Boolean.getBoolean(VERBOSE);
         local = Boolean.getBoolean(LOCAL);
         trace = Boolean.getBoolean(TRACE);
+
+        proxyVersion = intVersion(System.getProperty(PROXY_VERSION_PROP));
+        if (proxyVersion <= 0) {
+            proxyVersion = intVersion(System.getenv(PROXY_VERSION_ENV));
+        }
+        kvClientVersion = intVersion(System.getProperty(KVCLIENT_VERSION_PROP));
+        if (kvClientVersion <= 0) {
+            kvClientVersion = intVersion(System.getenv(KVCLIENT_VERSION_ENV));
+        }
+        kvServerVersion = intVersion(System.getProperty(KVSERVER_VERSION_PROP));
+        if (kvServerVersion <= 0) {
+            kvServerVersion = intVersion(System.getenv(KVSERVER_VERSION_ENV));
+        }
+
         /* these features are not yet available in the cloud */
         uuidSupported = onprem;
         arrayAsRecordSupported = onprem;
@@ -247,7 +274,7 @@ public class ProxyTestBase {
     public void afterTest() throws Exception {
 
         if (handle != null) {
-            dropAllTables(handle, false);
+            dropAllTables(handle, true);
             handle.close();
         }
     }
@@ -283,6 +310,12 @@ public class ProxyTestBase {
                 }
                 TableResult tres = dropTableWithoutWait(nosqlHandle, tableName);
                 droppedTables.add(tres);
+            } catch (TableNotFoundException tnfe) {
+                /* this is expected in 20.X and older */
+                if (checkKVVersion(21, 1, 1)) {
+                    System.err.println("DropAllTables: drop fail, table "
+                                       + tableName + ": " + tnfe);
+                }
             } catch (Exception e) {
                 System.err.println("DropAllTables: drop fail, table "
                                    + tableName + ": " + e);
@@ -306,6 +339,12 @@ public class ProxyTestBase {
             /* ignore, but note exceptions */
             try {
                 tres.waitForCompletion(nosqlHandle, 30000, 300);
+            } catch (TableNotFoundException tnfe) {
+                /* this is expected in 20.X and older */
+                if (checkKVVersion(21, 1, 1)) {
+                    System.err.println("DropAllTables: drop wait fail, table "
+                                       + tres + ": " + tnfe);
+                }
             } catch (Exception e) {
                 System.err.println("DropAllTables: drop wait fail, table "
                                    + tres + ": " + e);
@@ -318,13 +357,20 @@ public class ProxyTestBase {
     }
 
     static void dropTable(NoSQLHandle nosqlHandle, String tableName) {
-        TableResult tres = dropTableWithoutWait(nosqlHandle, tableName);
+        try {
+            TableResult tres = dropTableWithoutWait(nosqlHandle, tableName);
 
-        if (tres.getTableState().equals(TableResult.State.DROPPED)) {
-            return;
+            if (tres.getTableState().equals(TableResult.State.DROPPED)) {
+                return;
+            }
+
+            tres.waitForCompletion(nosqlHandle, 20000, 1000);
+        } catch (TableNotFoundException e) {
+            /* 20.2 and below have a known issue with drop table */
+            if (checkKVVersion(20, 3, 1) == true) {
+                throw e;
+            }
         }
-
-        tres.waitForCompletion(nosqlHandle, 20000, 1000);
     }
 
     static private TableResult dropTableWithoutWait(NoSQLHandle nosqlHandle,
@@ -371,7 +417,7 @@ public class ProxyTestBase {
      * sub classes can override this to affect the handle config
      */
     protected void perTestHandleConfig(NoSQLHandleConfig config) {
-        // no-op
+        /* no-op */
     }
 
     /**
@@ -379,11 +425,14 @@ public class ProxyTestBase {
      */
     protected NoSQLHandle getHandle(NoSQLHandleConfig config) {
         /*
-         * Create a Logger, set to WARNING. TODO: use a property
-         * for level.
+         * Create a Logger, set to WARNING by default.
          */
         Logger logger = Logger.getLogger(getClass().getName());
-        logger.setLevel(Level.WARNING);
+        String level = System.getProperty("test.loglevel");
+        if (level == null) {
+            level = "WARNING";
+        }
+        logger.setLevel(Level.parse(level));
         config.setLogger(logger);
 
         /*
@@ -541,5 +590,84 @@ public class ProxyTestBase {
         if (verbose) {
             System.out.println(msg);
         }
+    }
+
+    /*
+     * convert a version string in X.Y.Z format to an
+     * integer value of (X * 1M) + (Y * 1K) + Z
+     * return -1 if the string isn't in valid X.Y.Z format
+     */
+    protected static int intVersion(String version) {
+        if (version == null || version.length() < 5) {
+            return -1;
+        }
+        String[] arr = version.split("\\.");
+        if (arr == null || arr.length != 3) {
+            return -1;
+        }
+        try {
+            return (Integer.parseInt(arr[0]) * 1000000) +
+                   (Integer.parseInt(arr[1]) * 1000) +
+                   Integer.parseInt(arr[2]);
+        } catch (Exception e) {}
+        return -1;
+    }
+
+    /*
+     * Inverse of above, for messages
+     */
+    protected static String stringVersion(int ver) {
+        if (ver <= 0) {
+            return "unknown";
+        }
+        return (ver / 1000000) + "." +
+               ((ver / 1000) % 1000) + "." +
+               (ver % 1000);
+    }
+
+    private static int getMinimumKVVersion() {
+        /*
+         * Use the minumum of the kv client and server versions to
+         * determine what features should be valid to test.
+         */
+        if (kvServerVersion <= 0) {
+            return kvClientVersion;
+        } else if (kvClientVersion <= 0) {
+            return kvServerVersion;
+        }
+        if (kvServerVersion < kvClientVersion) {
+            return kvServerVersion;
+        }
+        return kvClientVersion;
+    }
+
+    /*
+     * Used to skip test if run against KV prior to the specified version
+     * <major>.<minor>.<patch>.
+     */
+    protected static void assumeKVVersion(String test,
+                                          int major,
+                                          int minor,
+                                          int patch) {
+        if (checkKVVersion(major, minor, patch)) {
+            return;
+        }
+        assumeTrue("Skipping " + test + " if run against KV prior to " +
+                   (major + "." + minor + "." + patch) + ": " +
+                   stringVersion(getMinimumKVVersion()), false);
+    }
+
+    /*
+     * Returns true if the current KV is >= version <major.minor.patch>
+     */
+    public static boolean checkKVVersion(int major,
+                                         int minor,
+                                         int patch) {
+        int minVersion = getMinimumKVVersion();
+        if (minVersion <= 0) {
+            return false; // we have no way of knowing for sure
+        }
+        int desiredVersion = (major * 1000000) + (minor * 1000) + patch;
+        return (minVersion >= desiredVersion);
     }
 }


### PR DESCRIPTION
Added logic to manage versions of proxy, kvclient, and kvserver based on
envrionment or properties settings. Used for testing, to skip tests that may not
run properly against older versions. No changes to public APIs.

Version checks in various tests are done with the minimum of client and server kv versions.
The proxy version is not checked. All three values are available to tests if needed.