### PR TITLE
Added support for On-Demand tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## [Unreleased]
+
+### Added
+- Cloud only: Support for On-Demand tables in TableLimits
+- Row modification time made available in GetResult
+- Existing row modification time made available in PutResult and DeleteResult when operation fails and previous value is requested
+- On-Prem only: Support for setting Durability in write operations (put/delete/writeMultiple/multiDelete)
+
+### Changed
+- Internally, the SDK now detects the serial version of the server it's connected to, and adjusts its capabilities to match. If the server is an older version, and some features may not be available, client apps may get a one-time log message (at INFO level) with text like "The requested feature is not supported by the connected server".
+
 
 ## [5.2.31] 2022-01-28
 
@@ -78,7 +89,7 @@ NoSQLHandleConfig.setPoolMaxPending() and NoSQLHandleConfig.getPoolMaxPending().
   - Added new SignatureProvider constructors to allow use of an instance principal with delegation token in a file for authorization and authentication.
     - SignatureProvider.createInstancePrincipalForDelegation(File delegationTokenFile)
     - SignatureProvider.createInstancePrincipalForDelegation(String iamAuthUri, Region region, File delegationTokenFile, Logger logger)
-- Added is* methods on FieldValue for convenience checking of whether an instance is
+- Added methods on FieldValue for convenience checking of whether an instance is
 of a given type, e.g. FieldValue.isInteger(), etc.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ project. The version changes with each release.
 <dependency>
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.2.31</version>
+  <version>5.3.0</version>
 </dependency>
 ```
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.2.31</version>
+  <version>5.3.0</version>
   <packaging>jar</packaging>
 
   <organization>

--- a/driver/src/main/java/oracle/nosql/driver/Durability.java
+++ b/driver/src/main/java/oracle/nosql/driver/Durability.java
@@ -1,0 +1,234 @@
+/*-
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+/**
+ * Defines the durability characteristics associated with a standalone write
+ * (put or update) operation.
+ * <p>
+ * This is currently only supported in On-Prem installations. It is ignored
+ * in the cloud service.
+ * <p>
+ * The overall durability is a function of the {@link SyncPolicy} and {@link
+ * ReplicaAckPolicy} in effect for the Master, and the {@link SyncPolicy} in
+ * effect for each Replica.
+ * </p>
+ *
+ * @since 5.3.0
+ */
+public class Durability {
+
+    /**
+     * A convenience constant that defines a durability policy with COMMIT_SYNC
+     * for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_SYNC =
+        new Durability(SyncPolicy.SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * A convenience constant that defines a durability policy with
+     * COMMIT_NO_SYNC for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_NO_SYNC =
+        new Durability(SyncPolicy.NO_SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * A convenience constant that defines a durability policy with
+     * COMMIT_WRITE_NO_SYNC for Master commit synchronization.
+     *
+     * The policies default to COMMIT_NO_SYNC for commits of replicated
+     * transactions that need acknowledgment and SIMPLE_MAJORITY for the
+     * acknowledgment policy.
+     */
+    public static final Durability COMMIT_WRITE_NO_SYNC =
+        new Durability(SyncPolicy.WRITE_NO_SYNC,
+                       SyncPolicy.NO_SYNC,
+                       ReplicaAckPolicy.SIMPLE_MAJORITY);
+
+    /**
+     * Defines the synchronization policy to be used when committing a
+     * transaction. High levels of synchronization offer a greater guarantee
+     * that the transaction is persistent to disk, but trade that off for
+     * lower performance.
+     */
+    public enum SyncPolicy {
+
+        /**
+         *  Write and synchronously flush the log on transaction commit.
+         *  Transactions exhibit all the ACID (atomicity, consistency,
+         *  isolation, and durability) properties.
+         */
+        SYNC,
+
+        /**
+         * Do not write or synchronously flush the log on transaction commit.
+         * Transactions exhibit the ACI (atomicity, consistency, and isolation)
+         * properties, but not D (durability); that is, database integrity will
+         * be maintained, but if the application or system fails, it is
+         * possible some number of the most recently committed transactions may
+         * be undone during recovery. The number of transactions at risk is
+         * governed by how many log updates can fit into the log buffer, how
+         * often the operating system flushes dirty buffers to disk, and how
+         * often log checkpoints occur.
+         */
+        NO_SYNC,
+
+        /**
+         * Write but do not synchronously flush the log on transaction commit.
+         * Transactions exhibit the ACI (atomicity, consistency, and isolation)
+         * properties, but not D (durability); that is, database integrity will
+         * be maintained, but if the operating system fails, it is possible
+         * some number of the most recently committed transactions may be
+         * undone during recovery. The number of transactions at risk is
+         * governed by how often the operating system flushes dirty buffers to
+         * disk, and how often log checkpoints occur.
+         */
+        WRITE_NO_SYNC;
+    }
+
+    /**
+     * A replicated environment makes it possible to increase an application's
+     * transaction commit guarantees by committing changes to its replicas on
+     * the network. ReplicaAckPolicy defines the policy for how such network
+     * commits are handled.
+     */
+    public enum ReplicaAckPolicy {
+
+        /**
+         * All replicas must acknowledge that they have committed the
+         * transaction. This policy should be selected only if your replication
+         * group has a small number of replicas, and those replicas are on
+         * extremely reliable networks and servers.
+         */
+        ALL,
+
+        /**
+         * No transaction commit acknowledgments are required and the master
+         * will never wait for replica acknowledgments. In this case,
+         * transaction durability is determined entirely by the type of commit
+         * that is being performed on the master.
+         */
+        NONE,
+
+        /**
+         * A simple majority of replicas must acknowledge that they have
+         * committed the transaction. This acknowledgment policy, in
+         * conjunction with an election policy which requires at least a simple
+         * majority, ensures that the changes made by the transaction remains
+         * durable if a new election is held.
+         */
+        SIMPLE_MAJORITY;
+    }
+
+    /* The sync policy in effect on the Master node. */
+    private final SyncPolicy masterSync;
+
+    /* The sync policy in effect on a replica. */
+    final private SyncPolicy replicaSync;
+
+    /* The replica acknowledgment policy to be used. */
+    final private ReplicaAckPolicy replicaAck;
+
+    /**
+     * Creates an instance of a Durability specification.
+     *
+     * @param masterSync the SyncPolicy to be used when committing the
+     * transaction on the Master.
+     * @param replicaSync the SyncPolicy to be used remotely, as part of a
+     * transaction acknowledgment, at a Replica node.
+     * @param replicaAck the acknowledgment policy used when obtaining
+     * transaction acknowledgments from Replicas.
+     */
+    public Durability(SyncPolicy masterSync,
+                      SyncPolicy replicaSync,
+                      ReplicaAckPolicy replicaAck) {
+        this.masterSync = masterSync;
+        this.replicaSync = replicaSync;
+        this.replicaAck = replicaAck;
+    }
+
+    @Override
+    public String toString() {
+        return masterSync.toString() + "," +
+               replicaSync.toString() + "," +
+               replicaAck.toString();
+    }
+
+    /**
+     * Returns the transaction synchronization policy to be used on the Master
+     * when committing a transaction.
+     * @return the master transaction synchronization policy
+     */
+    public SyncPolicy getMasterSync() {
+        return masterSync;
+    }
+
+    /**
+     * Returns the transaction synchronization policy to be used by the replica
+     * as it replays a transaction that needs an acknowledgment.
+     * @return the replica transaction synchronization policy
+     */
+    public SyncPolicy getReplicaSync() {
+        return replicaSync;
+    }
+
+    /**
+     * Returns the replica acknowledgment policy used by the master when
+     * committing changes to a replicated environment.
+     * @return the replica acknowledgment policy
+     */
+    public ReplicaAckPolicy getReplicaAck() {
+        return replicaAck;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = (prime * result) + masterSync.hashCode();
+        result = (prime * result) + replicaAck.hashCode();
+        result = (prime * result) + replicaSync.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Durability)) {
+            return false;
+        }
+        Durability other = (Durability) obj;
+        if (!masterSync.equals(other.masterSync)) {
+            return false;
+        }
+        if (!replicaAck.equals(other.replicaAck)) {
+            return false;
+        }
+        if (!replicaSync.equals(other.replicaSync)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -150,7 +150,7 @@ public class NoSQLHandleConfig implements Cloneable {
     private List<String> ciphers;
 
     /**
-     * The protocols used by the driver, or null if not configured
+     * The SSL protocols used by the driver, or null if not configured
      * by the user.
      */
     private List<String> protocols;

--- a/driver/src/main/java/oracle/nosql/driver/UnsupportedProtocolException.java
+++ b/driver/src/main/java/oracle/nosql/driver/UnsupportedProtocolException.java
@@ -1,0 +1,27 @@
+/*-
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+/**
+ * This exception is thrown if the server does not support the current
+ * driver protocol version.
+ *
+ * @since 5.3.0
+ */
+public class UnsupportedProtocolException extends NoSQLException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @hidden
+     * @param msg the exception message
+     */
+    public UnsupportedProtocolException(String msg) {
+        super(msg);
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
@@ -391,4 +391,12 @@ public class NoSQLHandleImpl implements NoSQLHandle {
     public Client getClient() {
         return client;
     }
+
+    /**
+     * @hidden
+     * For testing use
+     */
+    public short getSerialVersion() {
+        return client.getSerialVersion();
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
@@ -7,6 +7,7 @@
 
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.Version;
@@ -149,6 +150,21 @@ public class DeleteRequest extends WriteRequest {
      */
     public DeleteRequest setTableName(String tableName) {
         super.setTableNameInternal(tableName);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value
+     *
+     * @return this
+     *
+     * @since 5.3.0
+     */
+    public DeleteRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteResult.java
@@ -57,6 +57,20 @@ public class DeleteResult extends WriteResult {
         return super.getExistingValueInternal();
     }
 
+    /**
+     * Returns the existing modification time if available. This is available
+     * only if the target row exists and the operation failed because of a
+     * {@link Version} mismatch and the corresponding {@link DeleteRequest}
+     * method {@link DeleteRequest#setReturnRow} was called with a true value.
+     *
+     * @return the modification time in milliseconds since Jan 1, 1970
+     *
+     * @since 5.3.0
+     */
+    public long getExistingModificationTime() {
+        return super.getExistingModificationTimeInternal();
+    }
+
     /* from Result */
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
@@ -1,0 +1,45 @@
+/*-
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.ops;
+
+import oracle.nosql.driver.Durability;
+
+/**
+ * @hidden
+ *
+ * Represents a base class for operations that support a
+ * {@link Durability} setting.
+ */
+public abstract class DurableRequest extends Request {
+
+    private Durability durability;
+
+    protected DurableRequest() {}
+
+    protected void setDurabilityInternal(Durability durability) {
+        this.durability = durability;
+    }
+
+    /**
+     * Returns the durability setting for this operation.
+     * On-prem only.
+     *
+     * @return durability, if set. Otherwise null.
+     */
+    public Durability getDurability() {
+        return durability;
+    }
+
+    /**
+     * @hidden
+     */
+    @Override
+    public boolean doesWrites() {
+        return true;
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetResult.java
@@ -10,6 +10,7 @@ package oracle.nosql.driver.ops;
 import oracle.nosql.driver.Consistency;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.Version;
+import oracle.nosql.driver.http.Client;
 import oracle.nosql.driver.values.MapValue;
 
 /**
@@ -26,6 +27,8 @@ public class GetResult extends Result {
     private MapValue value;
     private Version version;
     private long expirationTime;
+    private long modificationTime;
+    private Client client;
 
     /**
      * Returns the value of the returned row, or null if the row does not exist
@@ -69,6 +72,25 @@ public class GetResult extends Result {
     }
 
     /**
+     * Returns the modification time of the row.
+     * This value is valid only if the operation
+     * successfully returned a row ({@link #getValue} returns non-null).
+     *
+     * @return the modification time in milliseconds since January 1, 1970,
+     * or zero if the row does not exist
+     *
+     * @since 5.3.0
+     */
+    public long getModificationTime() {
+        if (modificationTime < 0 && client != null) {
+            client.oneTimeMessage("The requested feature is not supported by " +
+                                  "the connected server: getModificationTime");
+            return 0;
+        }
+        return modificationTime;
+    }
+
+    /**
      * @hidden
      * Internal use only.
      *
@@ -95,6 +117,21 @@ public class GetResult extends Result {
      */
     public GetResult setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
+        return this;
+    }
+
+    /**
+     * @hidden
+     * Internal use only.
+     *
+     * Sets the modification time.
+     *
+     * @param modificationTime the modification time
+     *
+     * @return this
+     */
+    public GetResult setModificationTime(long modificationTime) {
+        this.modificationTime = modificationTime;
         return this;
     }
 
@@ -160,5 +197,13 @@ public class GetResult extends Result {
     @Override
     public String toString() {
         return getJsonValue();
+    }
+
+    /*
+     * @hidden
+     * for internal use
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -6,6 +6,7 @@
  */
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.FieldRange;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
@@ -34,7 +35,7 @@ import oracle.nosql.driver.values.MapValue;
  * key still require the primary key.
  * @see NoSQLHandle#multiDelete
  */
-public class MultiDeleteRequest extends Request {
+public class MultiDeleteRequest extends DurableRequest {
 
     private MapValue key;
     private byte[] continuationKey;
@@ -191,6 +192,22 @@ public class MultiDeleteRequest extends Request {
      */
     public MultiDeleteRequest setTimeout(int timeoutMs) {
         super.setTimeoutInternal(timeoutMs);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     *
+     * @since 5.3.0
+     */
+    public MultiDeleteRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
@@ -7,6 +7,7 @@
 
 package oracle.nosql.driver.ops;
 
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.TimeToLive;
@@ -304,6 +305,22 @@ public class PutRequest extends WriteRequest {
      */
     public PutRequest setReturnRow(boolean value) {
         super.setReturnRowInternal(value);
+        return this;
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     *
+     * @since 5.3.0
+     */
+    public PutRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
         return this;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutResult.java
@@ -71,6 +71,20 @@ public class PutResult extends WriteResult {
         return super.getExistingValueInternal();
     }
 
+    /**
+     * Returns the existing modification time if available. This value will
+     * only be available if the conditional put operation failed and the request
+     * specified that return information be returned using
+     * {@link PutRequest#setReturnRow}.
+     *
+     * @return the existing modification time in milliseconds since Jan 1, 1970
+     *
+     * @since 5.3.0
+     */
+    public long getExistingModificationTime() {
+        return super.getExistingModificationTimeInternal();
+    }
+
     /* from Result */
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import oracle.nosql.driver.BatchOperationNumberLimitException;
+import oracle.nosql.driver.Durability;
 import oracle.nosql.driver.NoSQLHandle;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.iam.SignatureProvider;
@@ -39,7 +40,7 @@ import oracle.nosql.driver.ops.serde.SerializerFactory;
  * {@link WriteMultipleResult#getFailedOperationResult()}.
  * @see NoSQLHandle#writeMultiple
  */
-public class WriteMultipleRequest extends Request {
+public class WriteMultipleRequest extends DurableRequest {
 
     /* The list of requests */
     private final List<OperationRequest> operations;
@@ -155,6 +156,22 @@ public class WriteMultipleRequest extends Request {
     public void clear() {
         super.setTableNameInternal(null);
         operations.clear();
+    }
+
+    /**
+     * Sets the durability to use for the operation.
+     * on-prem only.
+     *
+     * @param durability the durability value. Set to null for
+     * the default durability setting on the kvstore server.
+     *
+     * @return this
+     *
+     * @since 5.3.0
+     */
+    public WriteMultipleRequest setDurability(Durability durability) {
+        setDurabilityInternal(durability);
+        return this;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleResult.java
@@ -217,6 +217,18 @@ public class WriteMultipleResult extends Result {
         }
 
         /**
+         * Returns the previous modification time associated with the key if
+         * available.
+         * @return the modification time if set, in milliseconds sine Jan 1,
+         * 1970
+         *
+         * @since 5.3.0
+         */
+        public long getExistingModificationTime() {
+            return super.getExistingModificationTimeInternal();
+        }
+
+        /**
          * Returns the value generated if the operation created a new value.
          * This can happen if the table contains an identity column or string
          * column declared as a generated UUID. If the table has no such

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
@@ -21,7 +21,7 @@ import oracle.nosql.driver.NoSQLHandleConfig;
  * about the existing value of the target row on failure. By default
  * no previous information is returned.
  */
-public abstract class WriteRequest extends Request {
+public abstract class WriteRequest extends DurableRequest {
 
     private boolean returnRow;
 
@@ -56,13 +56,5 @@ public abstract class WriteRequest extends Request {
                 (requestName +
                  " requires table name"));
         }
-    }
-
-    /**
-     * @hidden
-     */
-    @Override
-    public boolean doesWrites() {
-        return true;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteResult.java
@@ -9,6 +9,7 @@ package oracle.nosql.driver.ops;
 
 import oracle.nosql.driver.Version;
 import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.http.Client;
 
 /**
  * @hidden
@@ -19,6 +20,8 @@ import oracle.nosql.driver.values.MapValue;
 public class WriteResult extends Result {
     private Version existingVersion;
     private MapValue existingValue;
+    private long existingModificationTime;
+    private Client client;
 
     protected WriteResult() {}
 
@@ -37,6 +40,19 @@ public class WriteResult extends Result {
      */
     public MapValue getExistingValueInternal() {
         return existingValue;
+    }
+
+    /**
+     * @hidden
+     * @return the modification time
+     */
+    public long getExistingModificationTimeInternal() {
+        if (existingModificationTime < 0 && client != null) {
+            client.oneTimeMessage("The requested feature is not supported by " +
+                          "the connected server: getExistingModificationTime");
+            return 0;
+        }
+        return existingModificationTime;
     }
 
     /*
@@ -61,5 +77,24 @@ public class WriteResult extends Result {
     public WriteResult setExistingValue(MapValue existingValue) {
         this.existingValue = existingValue;
         return this;
+    }
+
+    /**
+     * @hidden
+     * @param existingModificationTime the modification time
+     * @return this
+     */
+    public WriteResult setExistingModificationTime(
+        long existingModificationTime) {
+        this.existingModificationTime = existingModificationTime;
+        return this;
+    }
+
+    /*
+     * @hidden
+     * for internal use
+     */
+    public void setClient(Client client) {
+        this.client = client;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/DeleteRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/DeleteRequestSerializer.java
@@ -51,7 +51,7 @@ class DeleteRequestSerializer extends BinaryProtocol implements Serializer {
         if (isSubRequest) {
             out.writeBoolean(deleteRq.getReturnRow());
         } else {
-            serializeWriteRequest(deleteRq,out);
+            serializeWriteRequest(deleteRq, out, serialVersion);
         }
         writeFieldValue(out, deleteRq.getKey());
         if (matchVersion != null) {
@@ -69,7 +69,7 @@ class DeleteRequestSerializer extends BinaryProtocol implements Serializer {
         deserializeConsumedCapacity(in, result);
         boolean success = in.readBoolean();
         result.setSuccess(success);
-        deserializeWriteResponse(in, result);
+        deserializeWriteResponse(in, result, serialVersion);
         return result;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/GetRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/GetRequestSerializer.java
@@ -7,6 +7,9 @@
 
 package oracle.nosql.driver.ops.serde;
 
+import static oracle.nosql.driver.util.BinaryProtocol.V2;
+import static oracle.nosql.driver.util.BinaryProtocol.V3;
+
 import java.io.IOException;
 
 import oracle.nosql.driver.ops.GetRequest;
@@ -39,11 +42,17 @@ class GetRequestSerializer extends BinaryProtocol implements Serializer {
 
         GetResult result = new GetResult();
         deserializeConsumedCapacity(in, result);
+        if (serialVersion < V3) {
+            result.setModificationTime(-1);
+        }
         boolean hasRow = in.readBoolean();
         if (hasRow) {
             result.setValue(readFieldValue(in).asMap());
             result.setExpirationTime(readLong(in));
             result.setVersion(readVersion(in));
+            if (serialVersion > V2) {
+                result.setModificationTime(readLong(in));
+            }
         }
         return result;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/GetTableRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/GetTableRequestSerializer.java
@@ -38,7 +38,7 @@ class GetTableRequestSerializer extends BinaryProtocol implements Serializer {
                                    short serialVersion)
         throws IOException {
 
-        return deserializeTableResult(in);
+        return deserializeTableResult(in, serialVersion);
     }
 
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/MultiDeleteRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/MultiDeleteRequestSerializer.java
@@ -29,6 +29,7 @@ class MultiDeleteRequestSerializer extends BinaryProtocol
         writeOpCode(out, OpCode.MULTI_DELETE);
         serializeRequest(mdRq, out);
         writeString(out, mdRq.getTableName());
+        writeDurability(out, mdRq.getDurability(), serialVersion);
         writeFieldValue(out, mdRq.getKey());
         writeFieldRange(out, mdRq.getRange());
         writeInt(out, mdRq.getMaxWriteKB());

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/PutRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/PutRequestSerializer.java
@@ -49,7 +49,7 @@ class PutRequestSerializer extends BinaryProtocol implements Serializer {
         if (isSubRequest) {
             out.writeBoolean(putRq.getReturnRow());
         } else {
-            serializeWriteRequest(putRq, out);
+            serializeWriteRequest(putRq, out, serialVersion);
         }
         out.writeBoolean(putRq.getExactMatch());
         writeInt(out, putRq.getIdentityCacheSize());
@@ -76,7 +76,7 @@ class PutRequestSerializer extends BinaryProtocol implements Serializer {
         }
 
         /* return row info */
-        deserializeWriteResponse(in, result);
+        deserializeWriteResponse(in, result, serialVersion);
 
         /* generated identity column value */
         deserializeGeneratedValue(in, result);

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/TableRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/TableRequestSerializer.java
@@ -38,6 +38,7 @@ class TableRequestSerializer extends BinaryProtocol implements Serializer {
             out.writeInt(limits.getReadUnits());
             out.writeInt(limits.getWriteUnits());
             out.writeInt(limits.getStorageGB());
+            writeCapacityMode(out, limits.getMode(), serialVersion);
             if (rq.getTableName() != null) {
                 /* table name may exist with limits */
                 out.writeBoolean(true);
@@ -56,6 +57,6 @@ class TableRequestSerializer extends BinaryProtocol implements Serializer {
                                    short serialVersion)
         throws IOException {
 
-        return deserializeTableResult(in);
+        return deserializeTableResult(in, serialVersion);
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/WriteMultipleRequestSerialier.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/WriteMultipleRequestSerialier.java
@@ -52,6 +52,9 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         /* The number of operations */
         writeInt(out, num);
 
+        /* Durability setting */
+        writeDurability(out, umRq.getDurability(), serialVersion);
+
         /* Operations */
         for (OperationRequest op : umRq.getOperations()) {
             int start = out.getOffset();
@@ -86,16 +89,17 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         if (succeed) {
             int num = readInt(in);
             for (int i = 0; i < num; i++) {
-                umResult.addResult(createOperationResult(in));
+                umResult.addResult(createOperationResult(in, serialVersion));
             }
         } else {
             umResult.setFailedOperationIndex(in.readByte());
-            umResult.addResult(createOperationResult(in));
+            umResult.addResult(createOperationResult(in, serialVersion));
         }
         return umResult;
     }
 
-    private OperationResult createOperationResult(ByteInputStream in)
+    private OperationResult createOperationResult(ByteInputStream in,
+                                                  short serialVersion)
         throws IOException {
 
         OperationResult opResult = new OperationResult();
@@ -112,7 +116,7 @@ class WriteMultipleRequestSerializer extends BinaryProtocol
         }
 
         /* Previous value and version */
-        deserializeWriteResponse(in, opResult);
+        deserializeWriteResponse(in, opResult, serialVersion);
 
         /* Generated value, if present */
         boolean hasGeneratedValue = in.readBoolean();

--- a/driver/src/main/java/oracle/nosql/driver/util/BinaryProtocol.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/BinaryProtocol.java
@@ -16,10 +16,16 @@ public final class BinaryProtocol {
 
     public static final short QUERY_V1 = 1;
 
+    public static final short V2 = 2;
+
+    public static final short V3 = 3;
+
     /**
-     * Serial version of the protocol
+     * Default serial version of the protocol.
+     * Note the actual version used may be less if the
+     * driver is connected to an older proxy.
      */
-    public static final short SERIAL_VERSION = 2;
+    public static final short DEFAULT_SERIAL_VERSION = V3;
 
     /**
      * Serial version of the sub-protocol related to queries
@@ -87,6 +93,20 @@ public final class BinaryProtocol {
     public static final int EVENTUAL = 1;
 
     /**
+     * Durability.
+     * note 1-offset is to distinguish between 0 (not set)
+     * and a purposefully set value
+     */
+    /* sync policy */
+    public static final int DURABILITY_SYNC = 1;
+    public static final int DURABILITY_NO_SYNC = 2;
+    public static final int DURABILITY_WRITE_NO_SYNC = 3;
+    /* ack policy */
+    public static final int DURABILITY_ALL = 1;
+    public static final int DURABILITY_NONE = 2;
+    public static final int DURABILITY_SIMPLE_MAJORITY = 3;
+
+    /**
      * Table state
      */
     public static final int ACTIVE = 0;
@@ -94,6 +114,12 @@ public final class BinaryProtocol {
     public static final int DROPPED = 2;
     public static final int DROPPING = 3;
     public static final int UPDATING = 4;
+
+    /**
+     * Table Limits mode
+     */
+    public static final int PROVISIONED = 1;
+    public static final int ON_DEMAND = 2;
 
     /**
      * Operation state
@@ -145,6 +171,10 @@ public final class BinaryProtocol {
     public static final int TENANT_DEPLOYMENT_LIMIT_EXCEEDED = 20;
     /* added in V2 */
     public static final int OPERATION_NOT_SUPPORTED = 21;
+    public static final int ETAG_MISMATCH = 22;
+    public static final int CANNOT_CANCEL_WORK_REQUEST = 23;
+    /* added in V3 */
+    public static final int UNSUPPORTED_PROTOCOL = 24;
 
     /*
      * Error codes for user throttling, range from 50 to 100(exclusive).

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -410,7 +410,16 @@ public class ProxyTestBase {
         /* allow test cases to add/modify handle config */
         perTestHandleConfig(config);
 
-        return getHandle(config);
+        NoSQLHandle h = getHandle(config);
+
+        /* this will set up the right protocol serial version */
+        try {
+            getTable("noop", h);
+        } catch (Exception e) {
+            /* ignore errors */
+        }
+
+        return h;
     }
 
     /**


### PR DESCRIPTION
- Cloud only: Support for On-Demand tables in TableLimits
- Row modification time made available in GetResult
- Existing row modification time made available in PutResult and DeleteResult when operation fails and previous value is requested
- On-Prem only: Support for setting Durability in write operations (put/delete/writeMultiple/multiDelete)

Changed:
- Internally, the SDK now detects the serial version of the server it's connected to, and adjusts its capabilities to match. If the server is an older version, and some features may not be available, client apps may get a one-time log message (at INFO level) with text like "The requested feature is not supported by the connected server".