### PR TITLE
Fixed possible errors in serial version negotiation

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -488,7 +488,7 @@ public class Client {
             }
 
             ResponseHandler responseHandler = null;
-            int serialVersionUsed = serialVersion;
+            short serialVersionUsed = serialVersion;
             ByteBuf buffer = null;
             long networkLatency;
             try {
@@ -932,11 +932,11 @@ public class Client {
      *
      * @throws IOException
      */
-    private int writeContent(ByteBuf content, Request kvRequest)
+    private short writeContent(ByteBuf content, Request kvRequest)
         throws IOException {
 
         final NettyByteOutputStream bos = new NettyByteOutputStream(content);
-        final int versionUsed = serialVersion;
+        final short versionUsed = serialVersion;
         bos.writeShort(versionUsed);
         kvRequest.createSerializer(factory).
             serialize(kvRequest,
@@ -1245,7 +1245,7 @@ public class Client {
      * @return true: version was decremented
      *         false: already at lowest version number.
      */
-    private synchronized boolean decrementSerialVersion(int versionUsed) {
+    private synchronized boolean decrementSerialVersion(short versionUsed) {
         if (serialVersion != versionUsed) {
             return true;
         }

--- a/driver/src/test/java/oracle/nosql/driver/InternalsTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/InternalsTest.java
@@ -1,0 +1,88 @@
+/*-
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import oracle.nosql.driver.ops.ListTablesRequest;
+
+public class InternalsTest extends ProxyTestBase {
+
+    @Override
+    protected void perTestHandleConfig(NoSQLHandleConfig config) {
+        config.setConnectionPoolSize(10);
+        config.setNumThreads(8);
+    }
+
+    @Before
+    @Override
+    /*
+     * Override the default beforeTest() so we do not make
+     * any requests at all to the server before the actual test
+     * is run. The default runs a ListTables request.
+     */
+    public void beforeTest() throws Exception {
+        handle = getHandle(endpoint);
+        /* do NOT list tables here */
+    }
+
+    @Test
+    public void serialSetupTest() {
+        /*
+         * Start N threads. Make them all run at the same time.
+         * Each thread will issue requests. Verify that none of them
+         * throw UnsupportedProtocolException. This verifies that the
+         * logic inside Client properly manages setting the serial version
+         * on the first request(s) that may happen in parallel.
+         *
+         * This test really only does anything if the server it's running
+         * against is an older version. But it's ok to run with the current
+         * server version anyway.
+         */
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger errors = new AtomicInteger(0);
+        final int numThreads = 5;
+        Thread[] threads = new Thread[numThreads];
+        for (int x=0; x<numThreads; x++) {
+            threads[x] = new Thread(() -> {
+                try { latch.await(); } catch (Exception e) {}
+                runRequests(errors);
+            });
+            threads[x].start();
+        }
+
+        latch.countDown();
+
+        /* wait for threads to finish */
+        for(int x=0; x<numThreads; x++) {
+            try { threads[x].join(); } catch (Exception e) {}
+        }
+        if (errors.get() > 0) {
+            fail("Got " + errors.get() + " errors");
+        }
+    }
+
+    private void runRequests(AtomicInteger errors) {
+        ListTablesRequest req = new ListTablesRequest()
+              .setLimit(1);
+        try {
+            for (int x=0; x<5; x++) {
+                handle.listTables(req);
+            }
+        } catch (Exception e) {
+            System.out.println("Got exception: " + e);
+            errors.incrementAndGet();
+        }
+    }
+}

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -387,7 +387,6 @@ public class ProxyTestBase {
     }
 
     protected NoSQLHandle getHandle(String ep) {
-
         NoSQLHandleConfig config = new NoSQLHandleConfig(ep);
         serviceURL = config.getServiceURL();
         return setupHandle(config);
@@ -395,7 +394,6 @@ public class ProxyTestBase {
 
     /* Set configuration values for the handle */
     protected NoSQLHandle setupHandle(NoSQLHandleConfig config) {
-
         /*
          * 5 retries, default retry algorithm
          */
@@ -412,12 +410,7 @@ public class ProxyTestBase {
 
         NoSQLHandle h = getHandle(config);
 
-        /* this will set up the right protocol serial version */
-        try {
-            getTable("noop", h);
-        } catch (Exception e) {
-            /* ignore errors */
-        }
+        /* serial version will be set by default ListTables() in beforeTest */
 
         return h;
     }


### PR DESCRIPTION
Fixed a case where the serial version negotiation logic might throw UnsupportedProtocolException if the client handle is used by many threads to do many requests immediately after creation, and if the client is connected to an older (V2) server.