### PR TITLE
Support session cookies.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
@@ -64,6 +64,11 @@ public class HttpConstants {
     public static final String CONTENT_LENGTH = "Content-Length";
 
     /**
+     * The name of the cookie header
+     */
+    public static final String COOKIE = "Cookie";
+
+    /**
      * The name of the date header
      */
     public static final String DATE = "date";


### PR DESCRIPTION
If set in response headers, allow setting a cookie named "session" to enable session persistence in load balancer routing.