### PR TITLE
Enable auth retry on clock skew error.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/AuthorizationProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/AuthorizationProvider.java
@@ -71,4 +71,10 @@ public interface AuthorizationProvider {
             headers.set(AUTHORIZATION, authString);
         }
     }
+
+    /**
+     * Invalidate any cached authorization strings.
+     */
+    public default void flushCache() {
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
@@ -860,16 +860,20 @@ public class SignatureProvider
     }
 
     private SignatureDetails getSignatureDetails(Request request) {
-        if (request.getIsRefresh() && refreshSigDetails != null) {
-            return refreshSigDetails;
-        }
-        /* if refresh requested but null, allow use of current */
-
-        if (currentSigDetails != null) {
-            return currentSigDetails;
+        SignatureDetails sigDetails =
+            (request.getIsRefresh() ? refreshSigDetails : currentSigDetails);
+        if (sigDetails != null) {
+            return sigDetails;
         }
 
-        logMessage(Level.WARNING, "No signature in cache");
+        if (request.getIsRefresh()) {
+            /* try current details before failing */
+            sigDetails = currentSigDetails;
+            if (sigDetails != null) {
+                return sigDetails;
+            }
+        }
+
         return getSignatureDetailsInternal(false);
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -84,6 +84,7 @@ public abstract class Request {
     /**
      * @hidden
      * this is public to allow access from Client during refresh
+     * @param timeoutMs the request timeout, in milliseconds
      */
     public void setTimeoutInternal(int timeoutMs) {
         if (timeoutMs <= 0) {
@@ -454,6 +455,7 @@ public abstract class Request {
     /**
      * @hidden
      * Copy internal fields to another Request object.
+     * @param other the Request object to copy to.
      */
     public void copyTo(Request other) {
         other.setTimeoutInternal(this.timeoutMs);

--- a/driver/src/main/java/oracle/nosql/driver/ops/RetryStats.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/RetryStats.java
@@ -125,6 +125,8 @@ public class RetryStats {
      * @hidden
      * Internal use only.
      * Adds stats to the current object.
+     * @param rs the stats object to get values from to
+     * add to the current object.
      */
     public void addStats(RetryStats rs) {
         if (rs == null) {


### PR DESCRIPTION
If a request gets an authentication error that indicates a clock skew problem, clear the current authentication cached values and retry the operation once.
Also, use an internal datetime that is one minute ahead, to help align cached signature values across the valid time skew range.