### PR TITLE
Added Version.createVersion(byte[])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ query in an iterable/iterator format. The returned QueryIterableResult should
 be used in a try-with-resources statement to ensure proper closing of
 resources.
 - updated NoSQLHandle and QueryRequest interfaces to extend AutoClosable
+- added Version.createVersion(byte[]) to allow creation of a Version object from a
+query that returns row_version() as a BinaryValue. The Version can be used for
+conditional put and delete operations
 
 ### Changed
 - Cloud only: Updated OCI regions: CDG, MAD, QRO

--- a/driver/src/main/java/oracle/nosql/driver/Version.java
+++ b/driver/src/main/java/oracle/nosql/driver/Version.java
@@ -37,7 +37,10 @@ public class Version {
     }
 
     /**
-     * @hidden
+     * Creates a Version instance from a byte[] which may have been acquired
+     * from a query using the row_version() function which returns a FieldValue
+     * of type BINARY.
+     *
      * @param version the version to use
      * @return a new Version intance
      */


### PR DESCRIPTION
This allows easy creation of a Version from the return value of the row_version() function in a query.