### PR TITLE
Read rate limiter delay from response headers.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -25,6 +25,7 @@ import static oracle.nosql.driver.util.HttpConstants.COOKIE;
 import static oracle.nosql.driver.util.HttpConstants.NOSQL_DATA_PATH;
 import static oracle.nosql.driver.util.HttpConstants.REQUEST_ID_HEADER;
 import static oracle.nosql.driver.util.HttpConstants.USER_AGENT;
+import static oracle.nosql.driver.util.HttpConstants.X_RATELIMIT_DELAY;
 import static oracle.nosql.driver.util.LogUtil.isLoggable;
 import static oracle.nosql.driver.util.LogUtil.logFine;
 import static oracle.nosql.driver.util.LogUtil.logInfo;
@@ -199,9 +200,6 @@ public class Client {
     private volatile String sessionCookie;
     /* note this must end with '=' */
     private final String SESSION_COOKIE_FIELD = "session=";
-
-    /* header returned from proxy if request was delayed */
-    private final String X_RATE_LIMIT_DELAYED = "X-NoSQL-RLDelay-Ms";
 
     /* for keeping track of SDKs usage */
     private String userAgent;
@@ -1635,7 +1633,7 @@ public class Client {
         if (headers == null) {
             return 0;
         }
-        String v = headers.get(X_RATE_LIMIT_DELAYED);
+        String v = headers.get(X_RATELIMIT_DELAY);
         if (v == null || v.isEmpty()) {
             return 0;
         }

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -423,6 +423,16 @@ public abstract class Request {
         this.rateLimitDelayedMs = rateLimitDelayedMs;
     }
 
+    /**
+     * Get the time the operation was delayed due to rate limiting.
+     * Cloud only.
+     * If rate limiting is in place, this value will represent the number of
+     * milliseconds that the operation was delayed due to rate limiting.
+     * If the value is zero, rate limiting did not apply or the operation
+     * did not need to wait for rate limiting.
+     * @return delay time in milliseconds
+     * @since 5.2.25
+     */
     public int getRateLimitDelayedMs() {
         return rateLimitDelayedMs;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/Result.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Result.java
@@ -79,6 +79,7 @@ public class Result {
      * If the value is zero, rate limiting did not apply or the operation
      * did not need to wait for rate limiting.
      * @return delay time in milliseconds
+     * @since 5.2.25
      */
     public int getRateLimitDelayedMs() {
         return rateLimitDelayedMs;

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
@@ -129,6 +129,12 @@ public class HttpConstants {
     public static final String userAgent = makeUserAgent();
 
     /*
+     * If present, the amount of time the request was delayed due to
+     * rate limiting (in milliseconds).
+     */
+    public static final String X_RATELIMIT_DELAY = "X-Nosql-RL-Delay-Ms";
+
+    /*
      * Path Components
      */
 


### PR DESCRIPTION
The latest proxy with DRL enabled will set a new header in the response if it delays sending the response due to rate limiting. This code change reads that header and adds the value (in milliseconds) to the existing rate limit delay value.