### PR TITLE
Added methods to set default namespace (onprem only)

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -205,6 +205,18 @@ public class NoSQLHandleConfig implements Cloneable {
     private String compartment;
 
     /**
+     * Onprem use only.
+     *
+     * The default namespace to use for all requests. If this is null (the
+     * default), no namespace is used unless specified in table names in
+     * requests and SQL statements.
+     *
+     * Any namespace specified in a table name (using the namespace:tablename
+     * syntax) in requests and/or SQL statements overrides this default.
+     */
+    private String namespace;
+
+    /**
      * Enable rate limiting.
      * Cloud service only.
      */
@@ -1072,6 +1084,40 @@ public class NoSQLHandleConfig implements Cloneable {
      */
     public String getDefaultCompartment() {
         return compartment;
+    }
+
+    /**
+     * @hidden
+     *
+     * Onprem use only.
+     *
+     * Sets the default namespace to use for requests sent using the
+     * handle. This is an optional convenience method to avoid having to
+     * add the namespace to table names in requests and SQL statements.
+     *
+     * Any namespace specified in a table name (using the namespace:tablename
+     * syntax) in requests and/or SQL statements will override this default.
+     *
+     * @param namespace the default namespace to use
+     *
+     * @return this
+     */
+    public NoSQLHandleConfig setDefaultNamespace(String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    /**
+     * @hidden
+     *
+     * Onprem use only.
+     *
+     * Returns the default namespace to use for requests or null if not set.
+     *
+     * @return the namespace
+     */
+    public String getDefaultNamespace() {
+        return namespace;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -214,7 +214,7 @@ public class NoSQLHandleConfig implements Cloneable {
      * Any non-namespace qualified table name in requests and/or SQL
      * statements will be resolved/qualified to the specified namespace.
      */
-    private String namespace;
+    private String defaultNamespace;
 
     /**
      * Enable rate limiting.
@@ -1102,8 +1102,8 @@ public class NoSQLHandleConfig implements Cloneable {
      *
      * @return this
      */
-    public NoSQLHandleConfig setDefaultNamespace(String namespace) {
-        this.namespace = namespace;
+    public NoSQLHandleConfig setDefaultNamespace(String defaultNamespace) {
+        this.defaultNamespace = defaultNamespace;
         return this;
     }
 
@@ -1114,10 +1114,10 @@ public class NoSQLHandleConfig implements Cloneable {
      *
      * Returns the default namespace to use for requests or null if not set.
      *
-     * @return the namespace
+     * @return the default namespace
      */
     public String getDefaultNamespace() {
-        return namespace;
+        return defaultNamespace;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -205,14 +205,14 @@ public class NoSQLHandleConfig implements Cloneable {
     private String compartment;
 
     /**
-     * Onprem use only.
+     * On-premise only.
      *
      * The default namespace to use for all requests. If this is null (the
      * default), no namespace is used unless specified in table names in
      * requests and SQL statements.
      *
-     * Any namespace specified in a table name (using the namespace:tablename
-     * syntax) in requests and/or SQL statements overrides this default.
+     * Any non-namespace qualified table name in requests and/or SQL
+     * statements will be resolved/qualified to the specified namespace.
      */
     private String namespace;
 
@@ -1089,14 +1089,14 @@ public class NoSQLHandleConfig implements Cloneable {
     /**
      * @hidden
      *
-     * Onprem use only.
+     * On-premise only.
      *
      * Sets the default namespace to use for requests sent using the
      * handle. This is an optional convenience method to avoid having to
      * add the namespace to table names in requests and SQL statements.
      *
-     * Any namespace specified in a table name (using the namespace:tablename
-     * syntax) in requests and/or SQL statements will override this default.
+     * Any non-namespace qualified table name in requests and/or SQL
+     * statements will be resolved/qualified to the specified namespace.
      *
      * @param namespace the default namespace to use
      *
@@ -1110,7 +1110,7 @@ public class NoSQLHandleConfig implements Cloneable {
     /**
      * @hidden
      *
-     * Onprem use only.
+     * On-premise only.
      *
      * Returns the default namespace to use for requests or null if not set.
      *

--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -22,6 +22,7 @@ import static oracle.nosql.driver.util.HttpConstants.CONNECTION;
 import static oracle.nosql.driver.util.HttpConstants.CONTENT_LENGTH;
 import static oracle.nosql.driver.util.HttpConstants.CONTENT_TYPE;
 import static oracle.nosql.driver.util.HttpConstants.COOKIE;
+import static oracle.nosql.driver.util.HttpConstants.REQUEST_NAMESPACE_HEADER;
 import static oracle.nosql.driver.util.HttpConstants.NOSQL_DATA_PATH;
 import static oracle.nosql.driver.util.HttpConstants.REQUEST_ID_HEADER;
 import static oracle.nosql.driver.util.HttpConstants.USER_AGENT;
@@ -617,6 +618,11 @@ public class Client {
                 }
                 authProvider.setRequiredHeaders(authString, kvRequest, headers);
 
+                if (config.getDefaultNamespace() != null) {
+                    headers.add(REQUEST_NAMESPACE_HEADER,
+                                config.getDefaultNamespace());
+                }
+
                 if (isLoggable(logger, Level.FINE) &&
                     !kvRequest.getIsRefresh()) {
                     logTrace(logger, "Request: " + requestClass +
@@ -799,7 +805,7 @@ public class Client {
                 /* reduce protocol version and try again */
                 if (decrementSerialVersion(serialVersionUsed) == true) {
                     exception = upe;
-                    logInfo(logger, "Got unsupported protocol error " +
+                    logFine(logger, "Got unsupported protocol error " +
                             "from server: decrementing serial version to " +
                             serialVersion + " and trying again.");
                     continue;
@@ -1646,5 +1652,13 @@ public class Client {
         }
 
         return 0;
+    }
+
+    /**
+     * @hidden
+     * For testing use
+     */
+    public void setDefaultNamespace(String ns) {
+        config.setDefaultNamespace(ns);
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
@@ -416,6 +416,15 @@ public class NoSQLHandleImpl implements NoSQLHandle {
     }
 
     /**
+     * @hidden
+     *
+     * Testing use only.
+     */
+    public void setDefaultNamespace(String ns) {
+        client.setDefaultNamespace(ns);
+    }
+
+    /**
      * Cloud service only.
      * The refresh method of this class is called when a Signature is refreshed
      * in SignatureProvider. This happens every 4 minutes or so. This mechanism

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
@@ -47,10 +47,10 @@ public class HttpConstants {
     public static final String REQUEST_COMPARTMENT_ID = "x-nosql-compartment-id";
 
     /**
-     * A header for transferring the namespace on an http request.
+     * A header for transferring the default namespace on an http request.
      * onprem use only.
      */
-    public static final String REQUEST_NAMESPACE_HEADER = "x-nosql-namespace";
+    public static final String REQUEST_NAMESPACE_HEADER = "x-nosql-default-ns";
 
     /**
      * Headers possibly set by the load balancer service to indicate original

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpConstants.java
@@ -47,6 +47,12 @@ public class HttpConstants {
     public static final String REQUEST_COMPARTMENT_ID = "x-nosql-compartment-id";
 
     /**
+     * A header for transferring the namespace on an http request.
+     * onprem use only.
+     */
+    public static final String REQUEST_NAMESPACE_HEADER = "x-nosql-namespace";
+
+    /**
      * Headers possibly set by the load balancer service to indicate original
      * IP address
      */


### PR DESCRIPTION
Methods are hidden for now.
Requires onprem KV version 22.3, patch revision 24 or higher.