### PR TITLE
Fixed an issue with timeouts.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -515,6 +515,10 @@ public class Client {
                 break;
             }
 
+            /* update iteration timeout in case limiters slept for some time */
+            thisTime = System.currentTimeMillis();
+            thisIterationTimeoutMs = timeoutMs - (int)(thisTime - startTime);
+
             final String authString =
                 authProvider.getAuthorizationString(kvRequest);
             authProvider.validateAuthString(authString);
@@ -565,6 +569,9 @@ public class Client {
                  * writeContent().
                  */
                 kvRequest.setCheckRequestSize(false);
+
+                /* update timeout in request to match this iteration timeout */
+                kvRequest.setTimeoutInternal(thisIterationTimeoutMs);
 
                 serialVersionUsed = writeContent(buffer, kvRequest);
 

--- a/driver/src/test/java/oracle/nosql/driver/QueryTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/QueryTest.java
@@ -1710,7 +1710,7 @@ public class QueryTest extends ProxyTestBase {
         if (onprem == false) {
             assumeKVVersion("testLowThroughput", 21, 3, 1);
         }
-        final int numRows = 500;
+        final int numRows = 30;
         String name = "testThroughput";
         String createTableDdl =
             "CREATE TABLE " + name +
@@ -1719,7 +1719,7 @@ public class QueryTest extends ProxyTestBase {
         tableOperation(handle, createTableDdl, new TableLimits(2, 20000, 1));
 
         MapValue value = new MapValue()
-            .put("bin", new byte[10000])
+            .put("bin", new byte[3000])
             .put("json", "abc");
         PutRequest putReq = new PutRequest().setTableName(name);
 
@@ -1732,7 +1732,9 @@ public class QueryTest extends ProxyTestBase {
         }
 
         /*
-         * Ensure that this query completes
+         * Ensure that this query completes.
+         * 30 rows of 3K+ each = ~90KB.
+         * at 2RUs/sec, that's about 45 seconds.
          */
         try (QueryRequest queryReq = newQueryRequest()) {
             queryReq.setStatement("select * from " + name);


### PR DESCRIPTION
This change ensures that the timeout sent to the server is always the amount of time remaining before the overall request times out, regardless of internal retries and/or internal rate limiting.

Also updated low throughput test to not take too long when server-side rate limiting is in place.