### PR TITLE
Add new test-only Bouncy Castle dependency

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -218,6 +218,17 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- IAM unit tests only - Bouncycastle has changed
+         the packaging since 1.69, classes needed by test
+         has been moved to bcutil-jdk15on.
+    -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk15on</artifactId>
+      <version>${bouncy.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/driver/src/test/java/oracle/nosql/driver/iam/InstancePrincipalsProviderTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/iam/InstancePrincipalsProviderTest.java
@@ -394,39 +394,6 @@ public class InstancePrincipalsProviderTest extends DriverTestBase {
     }
 
     @Test
-    public void testValidateKey()
-        throws Exception {
-
-        EXPIRING_TOKEN = true;
-
-        CertificateSupplier leaf = new DefaultCertificateSupplier(
-            getURLDetails(base + "/instance?cert.pem"),
-            getURLDetails(base + "/instance?key.pem"),
-            (char[]) null);
-
-        CertificateSupplier inter = new DefaultCertificateSupplier(
-            getURLDetails(base + "/instance?intermediate.pem"),
-            null,
-            (char[]) null);
-
-        InstancePrincipalsProvider provider =
-            InstancePrincipalsProvider.builder()
-            .setFederationEndpoint(base)
-            .setLeafCertificateSupplier(leaf)
-            .setIntermediateCertificateSuppliers(Collections.singleton(inter))
-            .setTenantId(tenantId)
-            .build();
-        provider.setMinTokenLifetime(REFRESH_WINDOW_SEC * 1000 + 100);
-        provider.prepare(new NoSQLHandleConfig("http://test"));
-        try {
-            provider.getKeyId();
-            fail("expected");
-        } catch (IllegalArgumentException iae) {
-            assertThat(iae.getMessage(), "less lifetime");
-        }
-    }
-
-    @Test
     public void testRegionURI() {
         for (Region r : Region.getOC1Regions()) {
             assertEquals(r.endpoint(),

--- a/driver/src/test/java/oracle/nosql/driver/iam/ResourcePrincipalProviderTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/iam/ResourcePrincipalProviderTest.java
@@ -207,36 +207,4 @@ public class ResourcePrincipalProviderTest extends DriverTestBase {
                      ResourcePrincipalClaimKeys.TENANT_ID_CLAIM_KEY),
                      "tenantId");
     }
-
-    @Test
-    public void testValidateKey()
-        throws Exception {
-
-        int refreshWindowSec = 1;
-        String token = expiringToken(TOKEN,
-                                     refreshWindowSec,
-                                     keypair.getPublicKey());
-        Path keyFile = Files.write(Paths.get(getTestDir(), "key.pem"),
-                                   keypair.getKey().getBytes(),
-                                   StandardOpenOption.CREATE);
-        SessionKeyPairSupplier keySupplier = new FileKeyPairSupplier(
-            keyFile.toAbsolutePath().toString(), null);
-        File tokenFile = new File(getTestDir(), "token");
-        Files.write(tokenFile.toPath(), token.getBytes());
-        FileSecurityTokenSupplier fileSupplier =
-            new FileSecurityTokenSupplier(keySupplier,
-                                          tokenFile.getAbsolutePath(),
-                                          null);
-        ResourcePrincipalProvider rpProvider =
-            new ResourcePrincipalProvider(fileSupplier,
-                                          keySupplier,
-                                          Region.US_ASHBURN_1);
-        rpProvider.setMinTokenLifetime((refreshWindowSec * 1000) + 100);
-        try {
-            rpProvider.getKeyId();
-            fail("expected");
-        } catch (IllegalArgumentException iae) {
-            assertThat(iae.getMessage(), "less lifetime");
-        }
-    }
 }


### PR DESCRIPTION
The newer Bouncy Castle versions moved test code to a different artifact. Include that for testing.
Also remove Instance and Resource Principal (local) tests that are no longer relevant