### PR TITLE
Added per-request namespace capability (on-premises only).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- On-premises only: added support for setting namespace on a per-request basis
+
+### Fixed
+- Internal: changed to use nanoTime() instead of currentTimeMillis() to avoid
+ possible issue if system clock rolls backwards
+- Additional internal per-request-iteration timeout corrections
+
 ## [5.4.9] 2023-02-14
 
 ### Added

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -205,7 +205,7 @@ public class NoSQLHandleConfig implements Cloneable {
     private String compartment;
 
     /**
-     * On-premise only.
+     * On-premises only.
      *
      * The default namespace to use for all requests. If this is null (the
      * default), no namespace is used unless specified in table names in
@@ -1087,9 +1087,9 @@ public class NoSQLHandleConfig implements Cloneable {
     }
 
     /**
-     * @hidden
+     * Set the default namespace to use for the handle.
      *
-     * On-premise only.
+     * On-premises only.
      *
      * Sets the default namespace to use for requests sent using the
      * handle. This is an optional convenience method to avoid having to
@@ -1098,9 +1098,14 @@ public class NoSQLHandleConfig implements Cloneable {
      * Any non-namespace qualified table name in requests and/or SQL
      * statements will be resolved/qualified to the specified namespace.
      *
+     * This value can be overridden on a per-request basis by calling
+     * setNamespace() on individual requests.
+     *
      * @param defaultNamespace the default namespace to use
      *
      * @return this
+     *
+     * @since 5.4.10
      */
     public NoSQLHandleConfig setDefaultNamespace(String defaultNamespace) {
         this.defaultNamespace = defaultNamespace;
@@ -1108,13 +1113,15 @@ public class NoSQLHandleConfig implements Cloneable {
     }
 
     /**
-     * @hidden
+     * Get the default namespace.
      *
-     * On-premise only.
+     * On-premises only.
      *
      * Returns the default namespace to use for requests or null if not set.
      *
      * @return the default namespace
+     *
+     * @since 5.4.10
      */
     public String getDefaultNamespace() {
         return defaultNamespace;

--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -478,7 +478,8 @@ public class Client {
         int thisIterationTimeoutMs = 0;
 
         do {
-            thisIterationTimeoutMs = getIterationTimeoutMs(timeoutMs, startNanos);
+            thisIterationTimeoutMs =
+                getIterationTimeoutMs(timeoutMs, startNanos);
 
             /*
              * Check rate limiters before executing the request.
@@ -644,8 +645,7 @@ public class Client {
                     namespace = config.getDefaultNamespace();
                 }
                 if (namespace != null) {
-                    headers.add(REQUEST_NAMESPACE_HEADER,
-                                config.getDefaultNamespace());
+                    headers.add(REQUEST_NAMESPACE_HEADER, namespace);
                 }
 
                 if (isLoggable(logger, Level.FINE) &&
@@ -831,8 +831,8 @@ public class Client {
             } catch (UnsupportedProtocolException upe) {
                 /* reduce protocol version and try again */
                 if (decrementSerialVersion(serialVersionUsed) == true) {
-                    // Don't set this exception: it's misleading
-                    // exception = upe;
+                    /* Don't set this exception: it's misleading */
+                    /* exception = upe; */
                     logFine(logger, "Got unsupported protocol error " +
                             "from server: decrementing serial version to " +
                             serialVersion + " and trying again.");

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
@@ -211,8 +211,8 @@ public class DeleteRequest extends WriteRequest {
 
     /**
      * Sets the optional request timeout value, in milliseconds. This overrides
-     * any default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * any default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -230,7 +230,8 @@ public class DeleteRequest extends WriteRequest {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
@@ -227,6 +227,26 @@ public class DeleteRequest extends WriteRequest {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public DeleteRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * @hidden
      */
     @Override

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetIndexesRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetIndexesRequest.java
@@ -103,6 +103,26 @@ public class GetIndexesRequest extends Request {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public GetIndexesRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * @hidden
      */
     @Override

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetIndexesRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetIndexesRequest.java
@@ -87,8 +87,8 @@ public class GetIndexesRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -106,7 +106,8 @@ public class GetIndexesRequest extends Request {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetRequest.java
@@ -148,6 +148,26 @@ public class GetRequest extends ReadRequest {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public GetRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * @hidden
      * Internal use only
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetRequest.java
@@ -132,8 +132,8 @@ public class GetRequest extends ReadRequest {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -151,7 +151,8 @@ public class GetRequest extends ReadRequest {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetTableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetTableRequest.java
@@ -90,8 +90,8 @@ public class GetTableRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -109,7 +109,8 @@ public class GetTableRequest extends Request {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/GetTableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/GetTableRequest.java
@@ -106,6 +106,26 @@ public class GetTableRequest extends Request {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public GetTableRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * @hidden
      */
     @Override

--- a/driver/src/main/java/oracle/nosql/driver/ops/ListTablesRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/ListTablesRequest.java
@@ -104,8 +104,8 @@ public class ListTablesRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/ListTablesRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/ListTablesRequest.java
@@ -129,6 +129,8 @@ public class ListTablesRequest extends Request {
      * @param namespace the namespace to use
      *
      * @return this
+     *
+     * @since 5.4.10
      */
     public ListTablesRequest setNamespace(String namespace) {
         this.namespace = namespace;
@@ -142,6 +144,7 @@ public class ListTablesRequest extends Request {
      *
      * @return the namespace
      */
+    @Override
     public String getNamespace() {
         return namespace;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -212,6 +212,26 @@ public class MultiDeleteRequest extends DurableRequest {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public MultiDeleteRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * @hidden
      */
     @Override

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -180,8 +180,8 @@ public class MultiDeleteRequest extends DurableRequest {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -215,7 +215,8 @@ public class MultiDeleteRequest extends DurableRequest {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/PrepareRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PrepareRequest.java
@@ -81,8 +81,8 @@ public class PrepareRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -100,7 +100,8 @@ public class PrepareRequest extends Request {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name in the SQL statement
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/PrepareRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PrepareRequest.java
@@ -97,6 +97,26 @@ public class PrepareRequest extends Request {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name in the SQL statement
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public PrepareRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * Sets whether the string value of the query execution plan should be
      * included in the {@link PrepareResult}.
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
@@ -326,8 +326,8 @@ public class PutRequest extends WriteRequest {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set in with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -345,7 +345,8 @@ public class PutRequest extends WriteRequest {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
@@ -342,6 +342,26 @@ public class PutRequest extends WriteRequest {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public PutRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * If true the value must be an exact match for the table schema or the
      * operation will fail. An exact match means that there are no required
      * fields missing and that there are no extra, unknown fields. The default

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -685,6 +685,26 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name in the SQL statement
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public QueryRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * Returns the timeout to use for the operation, in milliseconds. A value
      * of 0 indicates that the timeout has not been set.
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -669,8 +669,8 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -688,7 +688,8 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name in the SQL statement
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -41,6 +41,14 @@ public abstract class Request {
     protected String compartment;
 
     /**
+     * On-premises use only.
+     *
+     * Set the namespace to use for the operation. Note: if a namespace is
+     * also specified in the table name, that namespace will override this one.
+     */
+    protected String namespace;
+
+    /**
      *  @hidden
      */
     private boolean checkRequestSize = true;
@@ -53,7 +61,7 @@ public abstract class Request {
     /**
      * @hidden
      */
-    private long startTimeMs;
+    private long startNanos;
 
     /**
      * @hidden
@@ -173,8 +181,6 @@ public abstract class Request {
      * Sets the table name to use for the operation.
      *
      * @param tableName the table name
-     *
-     * @return this
      */
     protected void setTableNameInternal(String tableName) {
         this.tableName = tableName;
@@ -187,6 +193,31 @@ public abstract class Request {
      */
     public String getTableName() {
         return tableName;
+    }
+
+    /**
+     * @hidden
+     * internal use only
+     * Sets the namespace to use for the operation.
+     *
+     * @param namespace the namespace name
+     *
+     * @since 5.4.10
+     */
+    protected void setNamespaceInternal(String namespace) {
+        this.namespace = namespace;
+    }
+
+    /**
+     * Returns the namespace to use for the operation.
+     *
+     * Note: if a namespace is supplied in the table name for the operation,
+     * that namespace will override this one.
+     *
+     * @return the namespace, or null if not set
+     */
+    public String getNamespace() {
+        return namespace;
     }
 
     /**
@@ -404,19 +435,19 @@ public abstract class Request {
     /**
      * @hidden
      * internal use only
-     * @param ms start time of request processing
+     * @param nanos start nanos of request processing
      */
-    public void setStartTimeMs(long ms) {
-        startTimeMs = ms;
+    public void setStartNanos(long nanos) {
+        startNanos = nanos;
     }
 
     /**
      * @hidden
      * internal use only
-     * @return start time of request processing
+     * @return start nanos of request processing
      */
-    public long getStartTimeMs() {
-        return startTimeMs;
+    public long getStartNanos() {
+        return startNanos;
     }
 
     public void setRateLimitDelayedMs(int rateLimitDelayedMs) {
@@ -472,7 +503,7 @@ public abstract class Request {
         other.setCheckRequestSize(this.checkRequestSize);
         other.setCompartmentInternal(this.compartment);
         other.setTableNameInternal(this.tableName);
-        other.setStartTimeMs(this.startTimeMs);
+        other.setStartNanos(this.startNanos);
         other.setRetryStats(this.retryStats);
         other.setReadRateLimiter(this.readRateLimiter);
         other.setWriteRateLimiter(this.writeRateLimiter);

--- a/driver/src/main/java/oracle/nosql/driver/ops/SystemRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/SystemRequest.java
@@ -67,8 +67,8 @@ public class SystemRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/SystemStatusRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/SystemStatusRequest.java
@@ -79,8 +79,8 @@ public class SystemStatusRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableRequest.java
@@ -252,6 +252,26 @@ public class TableRequest extends Request {
         return this;
     }
 
+    /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public TableRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
     /*
      * use table request timeout
      */

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableRequest.java
@@ -237,8 +237,8 @@ public class TableRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setTableRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -256,7 +256,8 @@ public class TableRequest extends Request {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableResult.java
@@ -132,7 +132,7 @@ public class TableResult extends Result {
     }
 
     /**
-     * On-premise service only.
+     * On-premises service only.
      * <p>
      * Returns the namespace of the table, or null if it is not in a namespace.
      * Note that the tablename is prefixed with the namespace as well if it

--- a/driver/src/main/java/oracle/nosql/driver/ops/TableUsageRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/TableUsageRequest.java
@@ -237,8 +237,8 @@ public class TableUsageRequest extends Request {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
@@ -135,8 +135,8 @@ public class WriteMultipleRequest extends DurableRequest {
 
     /**
      * Sets the request timeout value, in milliseconds. This overrides any
-     * default value set in {@link NoSQLHandleConfig}. The value must be
-     * positive.
+     * default value set with {@link NoSQLHandleConfig#setRequestTimeout}.
+     * The value must be positive.
      *
      * @param timeoutMs the timeout value, in milliseconds
      *
@@ -154,7 +154,8 @@ public class WriteMultipleRequest extends DurableRequest {
      * Sets the optional namespace.
      * On-premises only.
      *
-     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * This overrides any default value set with
+     * {@link NoSQLHandleConfig#setDefaultNamespace}.
      * Note: if a namespace is specified in the table name for the request
      * (using the namespace:tablename format), that value will override this
      * setting.

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteMultipleRequest.java
@@ -151,6 +151,26 @@ public class WriteMultipleRequest extends DurableRequest {
     }
 
     /**
+     * Sets the optional namespace.
+     * On-premises only.
+     *
+     * This overrides any default value set in {@link NoSQLHandleConfig}.
+     * Note: if a namespace is specified in the table name for the request
+     * (using the namespace:tablename format), that value will override this
+     * setting.
+     *
+     * @param namespace the namespace to use for the operation
+     *
+     * @return this
+     *
+     * @since 5.4.10
+     */
+    public WriteMultipleRequest setNamespace(String namespace) {
+        super.setNamespaceInternal(namespace);
+        return this;
+    }
+
+    /**
      * Removes all of the operations from the WriteMultiple request.
      */
     public void clear() {


### PR DESCRIPTION
Added per-request namespace capability (on-premises only).

Also modified internal timing to use nanoTime() instead of
currentTimeMillis(), which can go backwards in specific instances,
and made per-request-iteration timeout values more accurate.