### PR TITLE
Avoid NPE when level is not set for stats logger.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Stats.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Stats.java
@@ -434,16 +434,18 @@ public class Stats {
             extraQueryStats = new ExtraQueryStats(statsControl);
         }
 
-        // Setup the scheduler for interval logging
+        // Set up the scheduler for interval logging
         Runnable runnable = () -> {
             try {
                 logClientStats();
             } catch (RuntimeException re) {
-                StringWriter stackTrace = new StringWriter();
-                re.printStackTrace(new PrintWriter(stackTrace));
-                statsControl.getLogger().log(Level.INFO,
-                    "Stats exception: " + re.getMessage() + "\n" +
-                        stackTrace);
+                if (statsControl.getLogger() != null) {
+                    StringWriter stackTrace = new StringWriter();
+                    re.printStackTrace(new PrintWriter(stackTrace));
+                    statsControl.getLogger().log(Level.INFO,
+                        "Stats exception: " + re.getMessage() + "\n" +
+                            stackTrace);
+                }
             }
         };
 
@@ -482,10 +484,12 @@ public class Stats {
         }
 
         // Output stats to logger.
-        String json = fvStats.toJson(statsControl.getPrettyPrint() ?
-            JsonOptions.PRETTY : null);
-        statsControl.getLogger().log(Level.INFO,
-            StatsControl.LOG_PREFIX + json);
+        if (statsControl.getLogger() != null) {
+            String json = fvStats.toJson(statsControl.getPrettyPrint() ?
+                JsonOptions.PRETTY : null);
+            statsControl.getLogger().log(Level.INFO,
+                StatsControl.LOG_PREFIX + json);
+        }
     }
 
     private MapValue generateFieldValueStats() {

--- a/driver/src/main/java/oracle/nosql/driver/http/StatsControlImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/StatsControlImpl.java
@@ -43,7 +43,8 @@ public class StatsControlImpl
 
         if (profile != Profile.NONE) {
             if (config.getStatsEnableLog() &&
-                logger.getLevel().intValue() > Level.INFO.intValue()) {
+                ( logger.getLevel() == null ||
+                  logger.getLevel().intValue() > Level.INFO.intValue())) {
                 logger.setLevel(Level.INFO);
             }
             logger.log(Level.INFO, LOG_PREFIX +


### PR DESCRIPTION
Avoid NPE when stats logger doesn't have a level set.