### PR TITLE
Updated rate limiter timeout message.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -924,7 +924,8 @@ public class Client {
         kvRequest.setRateLimitDelayedMs(rateDelayedMs);
         statsControl.observeError(kvRequest);
         throw new RequestTimeoutException(timeoutMs,
-            requestClass + " timed out: requestId=" + requestId + " " +
+            requestClass + " timed out:" +
+            (requestId.isEmpty() ? "" : " requestId=" + requestId) +
             " nextRequestId=" + nextRequestId() +
             " iterationTimeout=" + thisIterationTimeoutMs + "ms " +
             (kvRequest.getRetryStats() != null ?

--- a/driver/src/main/java/oracle/nosql/driver/util/SimpleRateLimiter.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/SimpleRateLimiter.java
@@ -181,7 +181,7 @@ public class SimpleRateLimiter implements RateLimiter {
         if (timeoutMs > 0 && msToSleep >= timeoutMs) {
             uninterruptibleSleep(timeoutMs);
             throw new TimeoutException("timed out waiting " + timeoutMs +
-                "ms for " + units + " units in rate limiter");
+                                       "ms due to rate limiting");
         }
 
         /* sleep for the requested time. */


### PR DESCRIPTION
Also updated regular timeout message to not show requestId if it is empty (to avoid confusion).