### PR TITLE
Fix comparison of BigDecimal values to use compareTo() instead of equals

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/values/NumberValue.java
+++ b/driver/src/main/java/oracle/nosql/driver/values/NumberValue.java
@@ -136,7 +136,7 @@ public class NumberValue extends FieldValue {
     @Override
     public boolean equals(Object other) {
         if (other instanceof NumberValue) {
-            return value.equals(((NumberValue) other).value);
+            return (value.compareTo(((NumberValue) other).value) == 0);
         }
         return false;
     }


### PR DESCRIPTION
This was picked up by an internal test failure. It is the result of using BigDecimal directly inside Number