### PR TITLE
Cleaned up "inactive channel" auth logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Moved a couple internal log messages to FINE instead of INFO
 - Cleaned up messaging when can't connect to server
+- Modified internal auth logic to avoid "inactive channel: retrying" messages
 
 ## [5.4.11] 2023-06-06
 

--- a/driver/src/main/java/oracle/nosql/driver/RetryableException.java
+++ b/driver/src/main/java/oracle/nosql/driver/RetryableException.java
@@ -22,6 +22,13 @@ public class RetryableException extends NoSQLException {
         super(msg);
     }
 
+    /**
+     * @hidden
+     */
+    protected RetryableException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
     @Override
     public boolean okToRetry() {
         return true;

--- a/driver/src/main/java/oracle/nosql/driver/SecurityInfoNotReadyException.java
+++ b/driver/src/main/java/oracle/nosql/driver/SecurityInfoNotReadyException.java
@@ -21,4 +21,8 @@ public class SecurityInfoNotReadyException extends RetryableException {
     public SecurityInfoNotReadyException(String msg) {
         super(msg);
     }
+
+    public SecurityInfoNotReadyException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
+++ b/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
@@ -282,11 +282,11 @@ public class HttpClient {
         return sslCtx;
     }
 
-    int getPort() {
+    public int getPort() {
         return port;
     }
 
-    String getHost() {
+    public String getHost() {
         return host;
     }
 
@@ -445,6 +445,15 @@ public class HttpClient {
          */
         pool.release(channel);
     }
+
+    /**
+     * Close and remove channel from client pool.
+     */
+    public void removeChannel(Channel channel) {
+        logFine(logger, "closing and removing channel " + channel);
+        pool.removeChannel(channel);
+    }
+
 
     /**
      * Sends an HttpRequest, setting up the ResponseHandler as the handler to

--- a/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClientChannelPoolHandler.java
+++ b/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClientChannelPoolHandler.java
@@ -153,6 +153,7 @@ public class HttpClientChannelPoolHandler implements ChannelPoolHandler,
             logFine(client.getLogger(),
                     "HttpClient " + client.getName() +
                     ", channel " + ctx.channel() + " inactive");
+            client.removeChannel(ctx.channel());
             ctx.fireChannelInactive();
         }
 

--- a/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
@@ -232,7 +232,7 @@ class SecurityTokenSupplier {
 
             return new SecurityToken(securityToken, keyPairSupplier);
         } catch (Exception e) {
-            throw new SecurityInfoNotReadyException(e.getMessage());
+            throw new SecurityInfoNotReadyException(e.getMessage(), e);
         }
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpRequestUtil.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpRequestUtil.java
@@ -288,7 +288,10 @@ public class HttpRequestUtil {
                 throw new RuntimeException(
                     "Unable to execute request: ", ee);
             } catch (TimeoutException te) {
-                throw new RuntimeException("Timeout exception: ", te);
+                throw new RuntimeException("Timeout exception: host=" +
+                                           httpClient.getHost() + " port=" +
+                                           httpClient.getPort() + " uri=" +
+                                           uri, te);
             } catch (Throwable t) {
                 /*
                  * this is likely an exception from Netty, perhaps a bad


### PR DESCRIPTION
- close and remove channel from queue on "inactive" notification
- set promise to failed if channel is inactive
- added cause to AuthInfoNotReady exception
- add host, port, uri to timeout exception message