### PR TITLE
Use default table request time out for add/drop replica requests.

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/ops/AddReplicaRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/AddReplicaRequest.java
@@ -143,6 +143,17 @@ public class AddReplicaRequest extends Request {
         return this;
     }
 
+    /*
+     * use the default request timeout if not set.
+     */
+    @Override
+    public AddReplicaRequest setDefaults(NoSQLHandleConfig config) {
+        if (timeoutMs == 0) {
+            timeoutMs = config.getDefaultTableRequestTimeout();
+        }
+        return this;
+    }
+
     @Override
     public void validate() {
         if (tableName == null || replicaName == null) {

--- a/driver/src/main/java/oracle/nosql/driver/ops/DropReplicaRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DropReplicaRequest.java
@@ -97,6 +97,17 @@ public class DropReplicaRequest extends Request {
         return this;
     }
 
+    /*
+     * use the default request timeout if not set.
+     */
+    @Override
+    public DropReplicaRequest setDefaults(NoSQLHandleConfig config) {
+        if (timeoutMs == 0) {
+            timeoutMs = config.getDefaultTableRequestTimeout();
+        }
+        return this;
+    }
+
     @Override
     public void validate() {
         if (tableName == null || replicaName == null) {


### PR DESCRIPTION
Add/Drop requests are table request, the time out should default to table request time out.