### PR TITLE
Added sdk version to exception messages

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -429,6 +429,16 @@
         <version>3.1.0</version>
         <executions>
           <execution>
+            <id>Generate SDK Version strings</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <executable>${basedir}/scripts/generate_version_strings.sh</executable>
+            </configuration>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>human-readable NSON string generation</id>
             <phase>generate-sources</phase>
             <configuration>

--- a/driver/scripts/generate_version_strings.sh
+++ b/driver/scripts/generate_version_strings.sh
@@ -30,7 +30,13 @@ head -$lastline $SDK_VERSION_FILE > /tmp/sdkversion.$$
 
 # add SDKVersion class 
 cat << EOT >> /tmp/sdkversion.$$
+/**
+ * Public class to manage SDK version information
+ */
 public class SDKVersion {
+    /**
+     * The full X.Y.Z version of the current SDK
+     */
     public static final String VERSION = "$sdk_version";
 }
 EOT

--- a/driver/scripts/generate_version_strings.sh
+++ b/driver/scripts/generate_version_strings.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+#
+# This file was distributed by Oracle as part of a version of Oracle NoSQL
+# Database made available at:
+#
+# http://www.oracle.com/technetwork/database/database-technologies/nosqldb/downloads/index.html
+#
+# Please see the LICENSE file included in the top-level directory of the
+# appropriate version of Oracle NoSQL Database for a copy of the license and
+# additional information.
+
+# this script creates java code to enable using human-readable strings for field
+# names in nson debug/logging/verbose output. It modifies NsonProtocol.java to
+# add a map of field names to human readable field names.
+
+SDK_VERSION_FILE=src/main/java/oracle/nosql/driver/SDKVersion.java
+
+# get the version string from pom file
+sdk_version=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
+if [ "$sdk_version" = "" ] ; then
+  echo "Error getting version from pom file"
+  exit 1
+fi
+
+# delete everything after the package declaration
+lastline=$(grep -n 'package oracle.nosql.driver' $SDK_VERSION_FILE | tail -1 | sed -e 's/:.*$//')
+head -$lastline $SDK_VERSION_FILE > /tmp/sdkversion.$$
+
+# add SDKVersion class 
+cat << EOT >> /tmp/sdkversion.$$
+public class SDKVersion {
+    public static final String VERSION = "$sdk_version";
+}
+EOT
+
+# replace file
+mv /tmp/sdkversion.$$ $SDK_VERSION_FILE
+echo "Set SDKVersion.VERSION to $sdk_version"
+exit 0
+

--- a/driver/src/main/java/oracle/nosql/driver/DriverMain.java
+++ b/driver/src/main/java/oracle/nosql/driver/DriverMain.java
@@ -72,7 +72,7 @@ public class DriverMain {
      * by maven.
      */
     private static String findVersion() {
-        return  NoSQLHandleConfig.class.getPackage().getImplementationVersion();
+        return SDKVersion.VERSION;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLException.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLException.java
@@ -21,7 +21,7 @@ public class NoSQLException extends RuntimeException {
      * @param msg the message
      */
     public /*protected*/ NoSQLException(String msg) {
-        super(msg);
+        super(msg + " (" + SDKVersion.VERSION + ")");
     }
 
     /**
@@ -31,7 +31,7 @@ public class NoSQLException extends RuntimeException {
      * @param cause the cause
      */
     public /*protected*/ NoSQLException(String msg, Throwable cause) {
-        super(msg, cause);
+        super(msg + " (" + SDKVersion.VERSION + ")", cause);
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -1,0 +1,10 @@
+/*-
+ * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+package oracle.nosql.driver;
+public class SDKVersion {
+    public static final String VERSION = "5.4.13";
+}

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -12,5 +12,5 @@ public class SDKVersion {
     /**
      * The full X.Y.Z version of the current SDK
      */
-    public static final String VERSION = "5.4.13-SNAPSHOT.crap";
+    public static final String VERSION = "5.4.13";
 }

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -5,6 +5,12 @@
  *  https://oss.oracle.com/licenses/upl/
  */
 package oracle.nosql.driver;
+/**
+ * Public class to manage SDK version information
+ */
 public class SDKVersion {
-    public static final String VERSION = "5.4.13";
+    /**
+     * The full X.Y.Z version of the current SDK
+     */
+    public static final String VERSION = "5.4.13-SNAPSHOT.crap";
 }

--- a/driver/src/test/java/oracle/nosql/driver/HandleConfigTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/HandleConfigTest.java
@@ -8,6 +8,8 @@
 package oracle.nosql.driver;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
@@ -92,6 +94,17 @@ public class HandleConfigTest {
         } catch(IllegalArgumentException expected) {
             // expect a failure
         }
+    }
+
+    @Test
+    public void testSdkVersion() {
+        final String version = NoSQLHandleConfig.getLibraryVersion();
+        assertNotNull("SDK version should be non-null", version);
+        /* check that version string has three dot-separated parts */
+        String[] arr = version.split("\\.", -1);
+        assertTrue("SDK version \"" + version +
+                   "\" should have at least three dot-separated parts",
+                   arr.length > 2);
     }
 
     private void expectIllegalArg(String endpoint) {


### PR DESCRIPTION
The version is extracted from the pom file and put into SDKVersion.java. The old method that looked in the manifest now uses SDKVersion.