### PR TITLE
Update comments related to Request.oboToken to clarify that it is only required by Java SDK

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -1842,6 +1842,9 @@ public class Client {
          * because in the client it's not known if the operation is on a
          * multi-region table or not. This is a small bit of overhead and
          * is ignored if the table is not multi-region
+         *
+         * The Request.oboToken is not required by non Java SDKs, remove
+         * request.getOboToken() != null if there is no Request.oboToken
          */
         return request instanceof AddReplicaRequest ||
                request instanceof DropReplicaRequest ||

--- a/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
@@ -1086,6 +1086,14 @@ public class SignatureProvider
         return sigDetails;
     }
 
+    /*
+     * Since Request.oboToken is not required by non Java SDKs, if there
+     * is no Request.oboToken, simplify this method as following:
+     *
+     * private String getDelegationToken(Request req) {
+     *     return delegationToken;
+     * }
+     */
     private String getDelegationToken(Request req) {
         return (req != null && req.getOboToken() != null) ?
                req.getOboToken() : delegationToken;

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -85,7 +85,8 @@ public abstract class Request {
 
     /**
      * @hidden
-     * This is only used by internal, cross-region requests
+     * This is only required by Java SDK for internal cross-region request, not
+     * by other drivers.
      */
     private String oboToken;
 
@@ -569,7 +570,9 @@ public abstract class Request {
 
     /**
      * @hidden
-     * internal use only
+     * This is only required by Java SDK for internal cross-region request, not
+     * by other drivers.
+     *
      * @param token the on-behalf-of token
      */
     public void setOboTokenInternal(String token) {
@@ -578,7 +581,9 @@ public abstract class Request {
 
     /**
      * @hidden
-     * internal use only
+     * This is only required by Java SDK for internal cross-region request, not
+     * by other drivers.
+     *
      * @return the on-behalf-of token
      */
     public String getOboToken() {


### PR DESCRIPTION
The Request.oboToken is only required by Java SDK for internal cross-region request, it is not necessary for other drivers. Add comments to Request.oboToken and its callers to clarify this.