### PR TITLE
Fix performance of handle close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Cloud only: added new OCI regions (TYO, AHU, DAC, DOH, IZQ)
 - Cloud only: added use of ETag in AddReplicaRequest and DropReplicaRequest
 
+### Fixed
+- Changed handle close to not use the Netty "quiet period" when shutting down
+  the worker group. This makes handle close much faster as well as making it
+  faster to acquire authentication information in the cloud service when using a
+  method that uses an HTTP request such as Instance Principal authentication
+
 ## [5.4.14] 2023-11-17
 
 ### Added

--- a/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
+++ b/driver/src/main/java/oracle/nosql/driver/httpclient/HttpClient.java
@@ -366,7 +366,16 @@ public class HttpClient {
      */
     public void shutdown() {
         pool.close();
-        workerGroup.shutdownGracefully().syncUninterruptibly();
+        /*
+         * 0 means no quiet period, waiting for more tasks
+         * 5000ms is total time to wait for shutdown (should never take this
+         * long
+         *
+         * See doc:
+         * https://netty.io/4.1/api/io/netty/util/concurrent/EventExecutorGroup.html#shutdownGracefully--
+         */
+        workerGroup.shutdownGracefully(0, 5000, TimeUnit.MILLISECONDS).
+            syncUninterruptibly();
     }
 
     public Channel getChannel(int timeoutMs)


### PR DESCRIPTION
Don't use the default Netty "quiet time" when shutting down the worker group. This also affects cloud service authentication methods that use HTTP requests to acquire authentication information, such as Instance Principal