### PR TITLE
Re-check on-premises auth string while under lock

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/kv/StoreAccessTokenProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/kv/StoreAccessTokenProvider.java
@@ -222,7 +222,8 @@ public class StoreAccessTokenProvider implements AuthorizationProvider {
      */
     public synchronized void bootstrapLogin() {
 
-        if (!isSecure || isClosed) {
+        /* re-check the authString in case of a race */
+        if (!isSecure || isClosed || authString.get() != null) {
             return;
         }
 


### PR DESCRIPTION
Don't login again if, after waiting for on-premises kv login the auth string has been fetched