### PR TITLE
Avoid caching full query result for queries with generic sort and LIM…

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -630,7 +630,7 @@ public class Client {
                  */
                 kvRequest.setTimeoutInternal(thisIterationTimeoutMs);
                 serialVersionUsed = writeContent(buffer, kvRequest,
-                    queryVersionUsed);
+                                                 queryVersionUsed);
                 kvRequest.setTimeoutInternal(timeoutMs);
 
                 /*
@@ -1616,11 +1616,11 @@ public class Client {
         if (queryVersion != versionUsed) {
             return true;
         }
-        if (queryVersion == QueryDriver.QUERY_V4) {
-            queryVersion = QueryDriver.QUERY_V3;
-            return true;
+        if (queryVersion == QueryDriver.QUERY_V3) {
+            return false;
         }
-        return false;
+        --queryVersion;
+        return true;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
@@ -1008,7 +1008,7 @@ public class NsonSerializerFactory implements SerializerFactory {
 
                 } else if (name.equals(DRIVER_QUERY_PLAN)) {
                     dpi = getDriverPlanInfo(Nson.readNsonBinary(in),
-                                            serialVersion);
+                                            queryVersion);
 
                 } else if (name.equals(REACHED_LIMIT) && qres != null) {
                     qres.setReachedLimit(Nson.readNsonBoolean(in));
@@ -1179,7 +1179,7 @@ public class NsonSerializerFactory implements SerializerFactory {
         }
 
         private static DriverPlanInfo getDriverPlanInfo(byte[] arr,
-                                                        short serialVersion)
+                                                        short queryVersion)
             throws IOException {
             if (arr == null || arr.length == 0) {
                 return null;
@@ -1187,7 +1187,7 @@ public class NsonSerializerFactory implements SerializerFactory {
             ByteBuf buf = Unpooled.wrappedBuffer(arr);
             ByteInputStream bis = new NettyByteInputStream(buf);
             DriverPlanInfo dpi = new DriverPlanInfo();
-            dpi.driverQueryPlan = PlanIter.deserializeIter(bis, serialVersion);
+            dpi.driverQueryPlan = PlanIter.deserializeIter(bis, queryVersion);
             if (dpi.driverQueryPlan == null) {
                 return null;
             }

--- a/driver/src/main/java/oracle/nosql/driver/query/PlanIter.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/PlanIter.java
@@ -306,6 +306,9 @@ public abstract class PlanIter {
         StringBuilder sb,
         QueryFormatter formatter);
 
+    /*
+     * Note: the serialVersion param is actually the queryVersion.
+     */
     public static PlanIter deserializeIter(
         ByteInputStream in,
         short serialVersion) throws IOException {

--- a/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
@@ -35,7 +35,10 @@ public class QueryDriver {
     /* added query name in QueryRequest */
     public static short QUERY_V4 = 4;
 
-    public static short QUERY_VERSION = QUERY_V4;
+    /* added limit iter field in SortIter */
+    public static short QUERY_V5 = 5;
+
+    public static short QUERY_VERSION = QUERY_V5;
 
     private static final int BATCH_SIZE = 100;
 

--- a/driver/src/main/java/oracle/nosql/driver/query/SortIter.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/SortIter.java
@@ -10,6 +10,7 @@ package oracle.nosql.driver.query;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.PriorityQueue;
 
 import oracle.nosql.driver.query.PlanIterState.StateEnum;
 import oracle.nosql.driver.util.ByteInputStream;
@@ -25,35 +26,94 @@ import oracle.nosql.driver.values.MapValue;
  */
 public class SortIter extends PlanIter {
 
+    private class CompareFunction implements Comparator<MapValue> {
+
+        RuntimeControlBlock theRCB;
+
+        CompareFunction(RuntimeControlBlock rcb) {
+            theRCB = rcb;
+        }
+
+        @Override
+        public int compare(MapValue v1, MapValue v2) {
+
+            return Compare.sortResults(theRCB,
+                                       v1,
+                                       v2,
+                                       theSortFields,
+                                       theSortSpecs);
+        }
+    }
+
+    private static class ReverseCompareFunction implements Comparator<MapValue> {
+
+        CompareFunction theComparator;
+
+        ReverseCompareFunction(CompareFunction comparator) {
+            theComparator = comparator;
+        }
+
+        @Override
+        public int compare(MapValue v1, MapValue v2) {
+            return -theComparator.compare(v1, v2);
+        }
+    }
+
     private static class SortIterState extends PlanIterState {
 
-        final ArrayList<MapValue> theResults;
+        CompareFunction theComparator;
+
+        int theLimit = -1;
+
+        ArrayList<MapValue> theResults;
+
+        PriorityQueue<MapValue> theResultsQueue;
+
+        MapValue[] theResultsArray;
+
+        int theNumResults;
 
         int theCurrResult;
 
-        public SortIterState() {
+        public SortIterState(RuntimeControlBlock rcb, SortIter iter, int limit) {
             super();
-            theResults = new ArrayList<MapValue>(128);
+            theLimit = limit;
+            if (theLimit > 0) {
+                theResults = new ArrayList<MapValue>(theLimit);
+            } else {
+                theResults = new ArrayList<MapValue>(4096);
+            }
+            theComparator = iter.new CompareFunction(rcb);
         }
 
         @Override
         public void done() {
             super.done();
-            theCurrResult = 0;
-            theResults.clear();
+            theResults = null;
+            theResultsQueue = null;
+            theResultsArray = null;
         }
 
         @Override
         public void reset(PlanIter iter) {
             super.reset(iter);
             theCurrResult = 0;
-            theResults.clear();
+            theNumResults = 0;
+            if (theLimit > 0) {
+                theResults = new ArrayList<MapValue>(theLimit);
+            } else {
+                theResults = new ArrayList<MapValue>(4096);
+            }
+            theResultsQueue = null;
+            theResultsArray = null;
         }
 
         @Override
         public void close() {
             super.close();
-            theResults.clear();
+            theResults = null;
+            theResultsQueue = null;
+            theResultsArray = null;
         }
     }
 
@@ -63,13 +123,15 @@ public class SortIter extends PlanIter {
 
     private final SortSpec[] theSortSpecs;
 
+    private final PlanIter theLimit;
+
     private final boolean theCountMemory;
 
-    public SortIter(ByteInputStream in, PlanIterKind kind, short serialVersion)
+    public SortIter(ByteInputStream in, PlanIterKind kind, short queryVersion)
         throws IOException {
 
-        super(in, serialVersion);
-        theInput = deserializeIter(in, serialVersion);
+        super(in, queryVersion);
+        theInput = deserializeIter(in, queryVersion);
 
         theSortFields = SerializationUtil.readStringArray(in);
         theSortSpecs = readSortSpecs(in);
@@ -78,6 +140,12 @@ public class SortIter extends PlanIter {
             theCountMemory = in.readBoolean();
         } else {
             theCountMemory = true;
+        }
+
+        if (queryVersion >= QueryDriver.QUERY_V5) {
+            theLimit = deserializeIter(in, queryVersion);
+        } else {
+            theLimit = null;
         }
     }
 
@@ -93,7 +161,19 @@ public class SortIter extends PlanIter {
 
     @Override
     public void open(RuntimeControlBlock rcb) {
-        SortIterState state = new SortIterState();
+
+        rcb.trace("Opening SortIter");
+
+        int limit = - 1;
+
+        if (theLimit != null) {
+            theLimit.open(rcb);
+            theLimit.next(rcb);
+            FieldValue val = rcb.getRegVal(theLimit.getResultReg());
+            limit = val.getInt();
+        }
+
+        SortIterState state = new SortIterState(rcb, this, limit);
         rcb.setState(theStatePos, state);
         theInput.open(rcb);
     }
@@ -143,11 +223,55 @@ public class SortIter extends PlanIter {
                     }
                 }
 
-                state.theResults.add(v);
+                if (state.theLimit < 0) {
+                    state.theResults.add(v);
 
-                if (theCountMemory) {
-                    long sz = v.sizeof() + SizeOf.OBJECT_REF_OVERHEAD;
-                    rcb.incMemoryConsumption(sz);
+                    if (theCountMemory) {
+                        long sz = v.sizeof() + SizeOf.OBJECT_REF_OVERHEAD;
+                        rcb.incMemoryConsumption(sz);
+                    }
+                } else if (state.theResults != null &&
+                           state.theResults.size() < state.theLimit) {
+
+                    state.theResults.add(v);
+
+                    if (theCountMemory) {
+                        long sz = v.sizeof() + SizeOf.OBJECT_REF_OVERHEAD;
+                        rcb.incMemoryConsumption(sz);
+                    }
+
+                    if (state.theResults.size() == state.theLimit) {
+
+                        ReverseCompareFunction comparator =
+                        new ReverseCompareFunction(state.theComparator);
+
+                        state.theResultsQueue = new PriorityQueue<>(comparator);
+
+                        for (MapValue result : state.theResults) {
+                            state.theResultsQueue.add(result);
+                        }
+                        state.theResults = null;
+                    }
+                } else {
+                    MapValue lastResult = state.theResultsQueue.peek();
+
+                    if (state.theComparator.compare(lastResult, v) > 0) {
+
+                        state.theResultsQueue.remove();
+                        state.theResultsQueue.add(v);
+
+                        if (rcb.getTraceLevel() >= 4) {
+                            rcb.trace("SortIter: added top result: " + v +
+                                      "\nin place of " + lastResult);
+                        }
+
+                        if (theCountMemory) {
+                            long sz = v.sizeof();
+                            rcb.incMemoryConsumption(sz);
+                            sz = lastResult.sizeof();
+                            rcb.decMemoryConsumption(sz);
+                        }
+                    }
                 }
 
                 more = theInput.next(rcb);
@@ -157,22 +281,43 @@ public class SortIter extends PlanIter {
                 return false;
             }
 
-            state.theResults.sort(
-                    (v1, v2) -> Compare.sortResults(rcb,
-                                               v1,
-                                               v2,
-                                               theSortFields,
-                                               theSortSpecs));
+            if (state.theResultsQueue != null) {
+                /* Move the results from the queue to an array, maintaining their
+                 * sort order. This is needed because iterating over the queue
+                 * using an Iterator does not guarantee that the results will be
+                 * retrieved in their sorted order. */
+                state.theResultsArray = new MapValue[state.theLimit];
+
+                int i = state.theLimit - 1;
+                while (!state.theResultsQueue.isEmpty()) {
+                    MapValue result = state.theResultsQueue.remove();
+                    state.theResultsArray[i] = result;
+                    --i;
+                }
+
+                state.theResultsQueue = null;
+                state.theNumResults = state.theLimit;
+            } else {
+                state.theResults.sort(state.theComparator);
+                state.theNumResults = state.theResults.size();
+            }
 
             state.setState(StateEnum.RUNNING);
         }
 
-        if (state.theCurrResult < state.theResults.size()) {
+        if (state.theCurrResult < state.theNumResults) {
 
-            MapValue v = state.theResults.get(state.theCurrResult);
+            MapValue v;
+            if (state.theResultsArray == null) {
+                v = state.theResults.get(state.theCurrResult);
+                state.theResults.set(state.theCurrResult, null);
+            } else {
+                v = state.theResultsArray[state.theCurrResult]; 
+                state.theResultsArray[state.theCurrResult] = null;
+            }
+
             v.convertEmptyToNull();
             rcb.setRegVal(theResultReg, v);
-            state.theResults.set(state.theCurrResult, null);
             ++state.theCurrResult;
             return true;
         }


### PR DESCRIPTION
Queries that do generic sort and also include LIMIT clause, do not need to store that full query result in client memory, as it is done today. The just need to store a max of OFFSET+LIMIT results.