### PR TITLE
Put and Delete new semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+- Fixed an issue when stats collection is enabled debug logs were not 
+  logging.
+
+### Changed
+- Put and Put if-present can return the existing row when setReturnRow is 
+  set to true and row already exists.
+- Delete can return the deleted row when setReturnRow is set to true.
+
 ## [5.4.15] 2024-06-05
 
 ### Added

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandle.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandle.java
@@ -142,7 +142,8 @@ public interface NoSQLHandle extends AutoCloseable {
      * fails because the row exists and its version does not match.
      * </li>
      * <li> The {@link DeleteRequest#setMatchVersion} is not used and the
-     * operation succeeds.
+     * operation succeeds provided that the server supports providing the
+     * existing row.
      * </li>
      * </ul>
      * Use of {@link DeleteRequest#setReturnRow} may result in additional
@@ -157,10 +158,6 @@ public interface NoSQLHandle extends AutoCloseable {
      *
      * @throws NoSQLException if the operation cannot be performed for any other
      * reason
-     *
-     * @since 5.4.16 {@link DeleteRequest#setReturnRow} will return existing
-     * row(if provided by the server) even when operation succeeds as specified
-     * above.
      */
     DeleteResult delete(DeleteRequest request);
 
@@ -223,10 +220,12 @@ public interface NoSQLHandle extends AutoCloseable {
      * <li>The {@link Option#IfVersion} is used and the operation fails because
      * the row exists and its version does not match.
      * </li>
-     * <li>The {@link Option#IfPresent} is used and the operation succeeds.
+     * <li>The {@link Option#IfPresent} is used and the operation succeeds
+     * provided that the server supports providing the existing row.
      * </li>
      * <li>The {@link Option} is not used and put operation replaces the
-     * existing row.
+     * existing row provided that the server supports providing the existing
+     * row.
      * </li>
      * </ul>
      * Use of {@link PutRequest#setReturnRow} may result in additional
@@ -241,10 +240,6 @@ public interface NoSQLHandle extends AutoCloseable {
      *
      * @throws NoSQLException if the operation cannot be performed for any other
      * reason
-     *
-     * @since 5.4.16 {@link PutRequest#setReturnRow} will return existing
-     * row(if provided by the server) even when operation succeeds as specified
-     * above.
      */
     PutResult put(PutRequest request);
 

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandle.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandle.java
@@ -132,16 +132,21 @@ public interface NoSQLHandle extends AutoCloseable {
      * on whether the {@link Version} of an existing row matches that supplied
      * by {@link DeleteRequest#setMatchVersion}.
      * <p>
-     * It is also possible, on failure, to return information about the existing
-     * row. The row, including it's {@link Version} can be optionally returned
-     * if a delete operation fails because of a Version mismatch. The existing
-     * row information will only be returned if
-     * {@link DeleteRequest#setReturnRow} is true and the operation fails
-     * because {@link DeleteRequest#setMatchVersion} is used and the operation
+     * It is also possible to return information about the existing
+     * row. The row, including it's {@link Version} can be optionally returned.
+     * The existing row information will only be returned if
+     * {@link DeleteRequest#setReturnRow} is true and one of the following
+     * occurs:
+     * <ul>
+     * <li> The {@link DeleteRequest#setMatchVersion} is used and the operation
      * fails because the row exists and its version does not match.
+     * </li>
+     * <li> The {@link DeleteRequest#setMatchVersion} is not used and the
+     * operation succeeds.
+     * </li>
+     * </ul>
      * Use of {@link DeleteRequest#setReturnRow} may result in additional
-     * consumed read capacity. If the operation is successful there will be
-     * no information returned about the previous row.
+     * consumed read capacity.
      *
      * @param request the input parameters for the operation
      *
@@ -152,6 +157,10 @@ public interface NoSQLHandle extends AutoCloseable {
      *
      * @throws NoSQLException if the operation cannot be performed for any other
      * reason
+     *
+     * @since 5.4.16 {@link DeleteRequest#setReturnRow} will return existing
+     * row(if provided by the server) even when operation succeeds as specified
+     * above.
      */
     DeleteResult delete(DeleteRequest request);
 
@@ -204,22 +213,24 @@ public interface NoSQLHandle extends AutoCloseable {
      * {@link Version} matches that provided</li>
      * </ul>
      * <p>
-     * It is also possible, on failure, to return information about the existing
-     * row. The row, including it's {@link Version} can be optionally returned
-     * if a put operation fails because of a Version mismatch or if the
-     * operation fails because the row already exists. The existing row
-     * information will only be returned if {@link PutRequest#setReturnRow} is
-     * true and one of the following occurs:
+     * It is also possible to return information about the existing
+     * row. The row, including it's {@link Version} can be optionally returned.
+     * The existing row information will only be returned if
+     * {@link PutRequest#setReturnRow} is true and one of the following occurs:
      * <ul>
      * <li>The {@link Option#IfAbsent} is used and the operation fails because
      * the row already exists.</li>
      * <li>The {@link Option#IfVersion} is used and the operation fails because
      * the row exists and its version does not match.
      * </li>
+     * <li>The {@link Option#IfPresent} is used and the operation succeeds.
+     * </li>
+     * <li>The {@link Option} is not used and put operation replaces the
+     * existing row.
+     * </li>
      * </ul>
      * Use of {@link PutRequest#setReturnRow} may result in additional
-     * consumed read capacity. If the operation is successful there will be
-     * no information returned about the previous row.
+     * consumed read capacity.
      *
      * @param request the input parameters for the operation
      *
@@ -230,6 +241,10 @@ public interface NoSQLHandle extends AutoCloseable {
      *
      * @throws NoSQLException if the operation cannot be performed for any other
      * reason
+     *
+     * @since 5.4.16 {@link PutRequest#setReturnRow} will return existing
+     * row(if provided by the server) even when operation succeeds as specified
+     * above.
      */
     PutResult put(PutRequest request);
 

--- a/driver/src/main/java/oracle/nosql/driver/http/StatsControlImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/StatsControlImpl.java
@@ -42,9 +42,10 @@ public class StatsControlImpl
         this.statsHandler = config.getStatsHandler();
 
         if (profile != Profile.NONE) {
-            if (config.getStatsEnableLog() &&
-                ( logger.getLevel() == null ||
-                  logger.getLevel().intValue() > Level.INFO.intValue())) {
+            /* when stats collection is enabled set log level to INFO if it
+             * is not set.
+             */
+            if (config.getStatsEnableLog() && !logger.isLoggable(Level.INFO)) {
                 logger.setLevel(Level.INFO);
             }
             logger.log(Level.INFO, LOG_PREFIX +

--- a/driver/src/test/java/oracle/nosql/driver/BasicTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/BasicTest.java
@@ -292,7 +292,7 @@ public class BasicTest extends ProxyTestBase {
         newWrite = res.getWriteKB();
         assertEquals(2*origWrite, newWrite);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             assertEquals(0, newRead);
             assertNull("Not expecting previous version", res.getExistingVersion());
             assertNull("Not expecting previous value", res.getExistingValue());
@@ -646,7 +646,7 @@ public class BasicTest extends ProxyTestBase {
         putReq.setReturnRow(true);
         putRes = handle.put(putReq);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             /* expect no existing row returned */
             checkPutResult(putReq, putRes,
                            true /* shouldSucceed */,
@@ -734,13 +734,13 @@ public class BasicTest extends ProxyTestBase {
         putRes = handle.put(putReq);
         /* If proxy serial version <= V4,put success does not return row */
         if (proxySerialVersion <= V4) {
-        checkPutResult(putReq, putRes,
-                       true /* shouldSucceed */,
-                       false /* rowPresent */,
-                       null /* expPrevValue */,
-                       null /* expPrevVersion */,
-                       false, /* modtime should be zero */
-                       recordKB);
+            checkPutResult(putReq, putRes,
+                           true /* shouldSucceed */,
+                           false /* rowPresent */,
+                           null /* expPrevValue */,
+                           null /* expPrevVersion */,
+                           false, /* modtime should be zero */
+                           recordKB);
         } else {
             checkPutResult(putReq, putRes,
                            true /* shouldSucceed */,
@@ -1028,7 +1028,7 @@ public class BasicTest extends ProxyTestBase {
         delReq.setReturnRow(true);
         delRes = handle.delete(delReq);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             checkDeleteResult(delReq, delRes,
                               true /* shouldSucceed */,
                               false /* rowPresent */,

--- a/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/ProxyTestBase.java
@@ -122,6 +122,9 @@ public class ProxyTestBase {
 
     protected NoSQLHandle handle;
 
+    /* serial version used at the proxy server */
+    protected int proxySerialVersion;
+
     @Rule
     public final TestRule watchman = new TestWatcher() {
 
@@ -273,6 +276,7 @@ public class ProxyTestBase {
         existingTables = new HashSet<String>();
         ListTablesRequest listTables = new ListTablesRequest();
         ListTablesResult lres = handle.listTables(listTables);
+        proxySerialVersion = lres.getServerSerialVersion();
         for (String tableName: lres.getTables()) {
             existingTables.add(tableName);
         }

--- a/driver/src/test/java/oracle/nosql/driver/WriteMultipleTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/WriteMultipleTest.java
@@ -137,7 +137,7 @@ public class WriteMultipleTest extends ProxyTestBase {
             .setReturnRow(true);
         umRequest.add(put, false);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             rowPresent.add(false);
         } else {
             rowPresent.add(true);
@@ -175,7 +175,7 @@ public class WriteMultipleTest extends ProxyTestBase {
             .setReturnRow(true);
         umRequest.add(put, false);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             rowPresent.add(false);
         } else {
             rowPresent.add(true);
@@ -200,7 +200,7 @@ public class WriteMultipleTest extends ProxyTestBase {
             .setReturnRow(true);
         umRequest.add(delete, false);
         /* If proxy serial version <= V4,put success does not return row */
-        if (proxySerialVersion < V4) {
+        if (proxySerialVersion <= V4) {
             rowPresent.add(false);
         } else {
             rowPresent.add(true);
@@ -732,7 +732,7 @@ public class WriteMultipleTest extends ProxyTestBase {
             OperationResult opRet = ret.getResults().get(i);
             assertTrue(opRet.getSuccess());
             /* If proxy serial version <= V4,put success does not return row */
-            if (proxySerialVersion < V4) {
+            if (proxySerialVersion <= V4) {
                 assertNull(opRet.getExistingValue());
                 assertNull(opRet.getExistingVersion());
             } else {
@@ -836,7 +836,7 @@ public class WriteMultipleTest extends ProxyTestBase {
         for (OperationResult opRet: ret.getResults()) {
             assertTrue(opRet.getSuccess());
             /* If proxy serial version <= V4,put success does not return row */
-            if (proxySerialVersion < V4) {
+            if (proxySerialVersion <= V4) {
                 assertNull(opRet.getExistingValue());
                 assertNull(opRet.getExistingVersion());
             } else {


### PR DESCRIPTION
o. Updated JavaDoc for Put and Delete APIs
o. Updated tests for new put and delete semantics. Tests will use proxy serial version in
   the response to detect proxy version and test for old and new behaviour
o. Fixed debug logging issue when stats collection is enabled 
o. Updated CHANGELOG.md

Testing:
Tested against proxies with version V5, V4 and V3