### PR TITLE
Include bcutil-jdk18on.jar into the dependencies.

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -192,24 +192,12 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
       <version>${bouncy.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncy.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- test -->
@@ -220,16 +208,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- IAM unit tests only - Bouncycastle has changed
-         the packaging since 1.69, classes needed by test
-         has been moved to bcutil-jdk18on.
-    -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcutil-jdk18on</artifactId>
-      <version>${bouncy.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
When use Instance Principal Auth to run functional test(nosql-drvier 5.4.15), got java.lang.NoClassDefFoundError: org/bouncycastle/asn1/oiw/OIWObjectIdentifiers error, and the nosql-drvier 5.4.15 uses bouncy-castle 1.78. （see discussion in slack https://proddev-database.slack.com/archives/C9A0HCEMP/p1726487223705179?thread_ts=1726158296.764489&cid=C9A0HCEMP)

Bouncycastle has changed the packaging since 1.78, the org/bouncycastle/asn1/*.class are moved to bcutil-jdk18on.jar, so need include bcutil-jdk18on.jar into the dependencies of nosql driver.

In driver/pom.xml, all the dependencies of bcprov-jdk18on and bcpkix-jdk18on are explicitly excluded, and the bcutil-jdk18on is dependency for test scope only. The bcutil-jdk18on and bcprov-jdk18on are only dependencies of bcpkix-jdk18on, and no dependency for bcprov-jdk18on.

So to fix it, simply remove the dependency exclusions of bcpkix-jdk18on and bcprov-jdk18on, and also remove dependency of bcutil-jdk18on for test, then the bcutil-jdk18on will be included into dependencies.