### PR TITLE
Fix serialization problem using heap based netty ByteBuf

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/util/NettyByteInputStream.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/NettyByteInputStream.java
@@ -58,7 +58,11 @@ public class NettyByteInputStream extends ByteBufInputStream
 
     @Override
     public void setOffset(int offset) {
-        buffer.readerIndex(offset);
+        try {
+            buffer.readerIndex(offset);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     @Override

--- a/driver/src/main/java/oracle/nosql/driver/util/PackedInteger.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/PackedInteger.java
@@ -178,8 +178,20 @@ public class PackedInteger {
      */
     public static int getReadSortedIntLength(byte[] buf, int off) {
 
-        /* The first byte of the buf stores the length of the value part. */
-        int b1 = buf[off] & 0xff;
+        return getReadSortedIntLength(buf[off]);
+    }
+
+    /**
+     * Returns the number of bytes that would be read by {@link
+     * #readSortedInt} based on the initial byte of the buffer.
+     *
+     * @param value the byte containing the length
+     *
+     * @return the number of bytes that would be read.
+     */
+    public static int getReadSortedIntLength(byte value) {
+
+        int b1 = value & 0xff;
         if (b1 < 0x08) {
             return 1 + 0x08 - b1;
         }


### PR DESCRIPTION
The serialization code assumed that a non-direct Netty ByteBuf has a single contiguous byte array backing it and that is not the case. Remove the optimization for this case.
