### PR TITLE
Remove bouncy castle and change the exception for invalid security token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   provide local region information.
 - Cloud only: fixed a compatibility issue introduced in 5.4.15 regarding use of
   the Bouncy Castle artifacts. This would turn up when using Instance Principal
-  authentication
+  authentication, the bouncy castle artifacts have been removed and replaced
+  with oci-java-sdk-common-httpclient.
 
 ### Changed
 - Put and Put if-present can return the existing row when setReturnRow is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Cloud only: fixed a compatibility issue introduced in 5.4.15 regarding use of
   the Bouncy Castle artifacts. This would turn up when using Instance Principal
   authentication, the bouncy castle artifacts have been removed and replaced
-  with oci-java-sdk-common-httpclient.
+  with standard Java JCE APIs.
 
 ### Changed
 - Put and Put if-present can return the existing row when setReturnRow is

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -36,26 +36,6 @@ from the source code management (SCM) system project uses.
 ===============
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Bouncy Castle
-Copyright (c) 2000 - 2017 The Legion of the Bouncy Castle Inc.
-License:   modified MIT
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this
-software and associated documentation files (the "Software"), to deal in the Software
-without restriction, including without limitation the rights to use, copy, modify,
-merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or
-substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 jQuery UI for Javadoc 
 
 URL for License and Copyright Notice - https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -48,7 +48,7 @@
     <maven.deploy.skip>false</maven.deploy.skip>
     <netty.version>4.1.108.Final</netty.version>
     <jackson.version>2.15.2</jackson.version>
-    <bouncy.version>1.78</bouncy.version>
+    <oci.java.sdk.version>3.51.0</oci.java.sdk.version>
    <!-- by default, skip tests; tests require a profile -->
    <maven.test.skip>true</maven.test.skip>
    <javac>javac</javac>
@@ -249,17 +249,17 @@
       <version>${netty.version}</version>
     </dependency>
 
-    <!-- Bouncycastle - request signing in cloud -->
+    <!-- oci-java-sdk-common-httpclient - request signing in cloud -->
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
-      <version>${bouncy.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncy.version}</version>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common-httpclient</artifactId>
+      <version>${oci.java.sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test -->

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -48,7 +48,6 @@
     <maven.deploy.skip>false</maven.deploy.skip>
     <netty.version>4.1.108.Final</netty.version>
     <jackson.version>2.15.2</jackson.version>
-    <oci.java.sdk.version>3.51.0</oci.java.sdk.version>
    <!-- by default, skip tests; tests require a profile -->
    <maven.test.skip>true</maven.test.skip>
    <javac>javac</javac>
@@ -247,19 +246,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
       <version>${netty.version}</version>
-    </dependency>
-
-    <!-- oci-java-sdk-common-httpclient - request signing in cloud -->
-    <dependency>
-      <groupId>com.oracle.oci.sdk</groupId>
-      <artifactId>oci-java-sdk-common-httpclient</artifactId>
-      <version>${oci.java.sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- test -->

--- a/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLException;
 
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.Region;
+import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.httpclient.HttpClient;
 import oracle.nosql.driver.iam.SessionKeyPairSupplier.DefaultSessionKeySupplier;
 import oracle.nosql.driver.util.HttpRequestUtil;
@@ -222,6 +223,16 @@ class OkeWorkloadIdentityProvider
         final byte[] payloadByte = new byte[buf.remaining()];
         buf.get(payloadByte);
 
+        try {
+            return getSecurityTokenFromProxymux(requestId, saToken, payloadByte);
+        } catch (Exception e) {
+            throw new SecurityInfoNotReadyException(e.getMessage(), e);
+        }
+    }
+
+    private String getSecurityTokenFromProxymux(String requestId,
+                                                String saToken,
+                                                byte[] payloadByte) {
         HttpRequestUtil.HttpResponse response = HttpRequestUtil.doPostRequest(
             okeTokenClient, tokenURL.toString(), headers(saToken, requestId),
             payloadByte, timeoutMs, logger);

--- a/driver/src/main/java/oracle/nosql/driver/iam/PrivateKeyProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/PrivateKeyProvider.java
@@ -15,9 +15,9 @@ import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Arrays;
 
-import com.oracle.bmc.http.client.pki.Pem;
-import com.oracle.bmc.http.client.pki.PemEncryptionException;
-import com.oracle.bmc.http.client.pki.PemException;
+import oracle.nosql.driver.iam.pki.Pem;
+import oracle.nosql.driver.iam.pki.PemEncryptionException;
+import oracle.nosql.driver.iam.pki.PemException;
 
 /**
  * @hidden

--- a/driver/src/main/java/oracle/nosql/driver/iam/PrivateKeyProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/PrivateKeyProvider.java
@@ -7,37 +7,29 @@
 
 package oracle.nosql.driver.iam;
 
-import static oracle.nosql.driver.util.CheckNull.requireNonNullIAE;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.security.Provider;
-import java.security.Security;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.Arrays;
 
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.openssl.EncryptionException;
-import org.bouncycastle.openssl.PEMDecryptorProvider;
-import org.bouncycastle.openssl.PEMEncryptedKeyPair;
-import org.bouncycastle.openssl.PEMException;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
+import com.oracle.bmc.http.client.pki.Pem;
+import com.oracle.bmc.http.client.pki.PemEncryptionException;
+import com.oracle.bmc.http.client.pki.PemException;
 
 /**
  * @hidden
  * Internal use only
  * <p>
  * The RSA private key provider that loads and caches private key from input
- * stream using bouncy castle PEM key utilities.
+ * stream using PEM key utilities in oci-java-sdk.
+ *
+ * See com.oracle.bmc.http.signing.internal.PEMStreamRSAPrivateKeySupplier
+ * for reference.
  */
 class PrivateKeyProvider {
-    private final JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
     private RSAPrivateKey key = null;
 
     /**
@@ -66,79 +58,25 @@ class PrivateKeyProvider {
     }
 
     void getKeyInternal(InputStream keyInputStream, char[] passphrase) {
-        PEMParser keyReader = null;
-        try {
-            keyReader = new PEMParser(
-                new InputStreamReader(keyInputStream, StandardCharsets.UTF_8));
-
-            Object object = null;
-            try {
-                object = keyReader.readObject();
-            } catch (IOException ioe) {
-                throw new IllegalArgumentException(
-                    "Error reading private key", ioe);
-            }
-            PrivateKeyInfo keyInfo;
-
-            if (object instanceof PEMEncryptedKeyPair) {
-                requireNonNullIAE(
-                    passphrase,
-                    "The provided private key requires a passphrase");
-
-                JcePEMDecryptorProviderBuilder decryptBuilder =
-                    new JcePEMDecryptorProviderBuilder();
-
-                if (!isProviderInstalled()) {
-                    /*
-                     * If BouncyCastle is not installed, must add the provider
-                     * explicitly to enable the PEMDecrptorProvider.
-                     * https://github.com/bcgit/bc-java/issues/156
-                     */
-                    decryptBuilder.setProvider(getBouncyCastleProvider());
-                }
-
-                PEMDecryptorProvider decProv = decryptBuilder.build(passphrase);
-                try {
-                    keyInfo = ((PEMEncryptedKeyPair) object)
-                        .decryptKeyPair(decProv)
-                        .getPrivateKeyInfo();
-                } catch (EncryptionException ee) {
-                    throw new IllegalArgumentException(
-                            "The provided passphrase is incorrect.", ee);
-                } catch (IOException ioe) {
-                    throw new IllegalArgumentException(
-                        "Error decrypting private key.", ioe);
-                }
-            } else if (object instanceof PrivateKeyInfo) {
-                keyInfo = (PrivateKeyInfo) object;
-            } else if (object instanceof PEMKeyPair) {
-                keyInfo = ((PEMKeyPair) object).getPrivateKeyInfo();
-            } else if (object instanceof SubjectPublicKeyInfo) {
-                throw new IllegalArgumentException(
-                    "Public key provided instead of private key");
-            } else if (object != null) {
-                throw new IllegalArgumentException(
-                    "Private key must be in PEM format," +
-                    "was: " + object.getClass());
+        try (ReadableByteChannel channel = Channels.newChannel(keyInputStream);
+             Pem.Passphrase pemPassphrase = Pem.Passphrase.of(passphrase)){
+            PrivateKey privateKey =
+                Pem.decoder().with(pemPassphrase).decodePrivateKey(channel);
+            if (privateKey instanceof RSAPrivateKey) {
+                key = (RSAPrivateKey) privateKey;
             } else {
                 throw new IllegalArgumentException(
-                    "Private key must be in PEM format");
+                    "Must be RSA private key, but " + privateKey.toString());
             }
-
-            try {
-                this.key = (RSAPrivateKey) converter.getPrivateKey(keyInfo);
-            } catch (PEMException e) {
-                throw new IllegalArgumentException(
-                    "Error converting private key");
-            }
+        } catch (PemEncryptionException e) {
+            throw new IllegalArgumentException(
+                "The provided passphrase is incorrect.", e);
+        } catch (PemException e) {
+            throw new IllegalArgumentException(
+                "Private key must be in PEM format", e);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error reading private key", e);
         } finally {
-            if (keyReader != null) {
-                try {
-                    keyReader.close();
-                } catch (IOException e) {
-                    /* ignore */
-                }
-            }
             if (keyInputStream != null) {
                 try {
                     keyInputStream.close();
@@ -150,26 +88,5 @@ class PrivateKeyProvider {
                 Arrays.fill(passphrase, ' ');
             }
         }
-    }
-
-    private static boolean isProviderInstalled() {
-        return (Security.getProvider("BC") != null);
-    }
-
-    private static Provider getBouncyCastleProvider() {
-        Provider provider = null;
-        try {
-            Class<?> providerClass = Class.forName(
-                "org.bouncycastle.jce.provider.BouncyCastleProvider");
-            provider = (Provider)providerClass
-                .getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(
-                "Unable to find bouncy castle provider");
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                "Error creating bouncy castle provider");
-        }
-        return provider;
     }
 }

--- a/driver/src/main/java/oracle/nosql/driver/iam/ResourcePrincipalTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/ResourcePrincipalTokenSupplier.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.util.logging.Logger;
 
+import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.iam.SecurityTokenSupplier.SecurityToken;
 
 /**
@@ -91,11 +92,15 @@ abstract class ResourcePrincipalTokenSupplier {
             logTrace(logger, "Refreshing session keys");
             sessionKeyPairSupplier.refreshKeys();
 
-            logTrace(logger, "Getting security token from file.");
-            SecurityToken token = getSecurityTokenFromFile();
-            token.validate(minTokenLifetime, logger);
-            securityToken = token;
-            return securityToken.getSecurityToken();
+            try {
+                logTrace(logger, "Getting security token from file.");
+                SecurityToken token = getSecurityTokenFromFile();
+                token.validate(minTokenLifetime, logger);
+                securityToken = token;
+                return securityToken.getSecurityToken();
+            } catch (Exception e) {
+                throw new SecurityInfoNotReadyException(e.getMessage(), e);
+            }
         }
 
         SecurityToken getSecurityTokenFromFile() {

--- a/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
@@ -164,13 +164,10 @@ class SecurityTokenSupplier {
                 }
             }
         }
-        SecurityToken token = getSecurityTokenFromIAM();
-        token.validate(minTokenLifetime, logger);
-
-        return token.getSecurityToken();
+        return getSecurityTokenFromIAM();
     }
 
-    private SecurityToken getSecurityTokenFromIAM() {
+    private String getSecurityTokenFromIAM() {
         KeyPair keyPair = keyPairSupplier.getKeyPair();
         requireNonNullIAE(keyPair, "Keypair for session not provided");
 
@@ -211,7 +208,9 @@ class SecurityTokenSupplier {
                 Utils.base64EncodeNoChunking(certificateAndKeyPair),
                 intermediateStrings);
 
-            return new SecurityToken(securityToken, keyPairSupplier);
+            SecurityToken st = new SecurityToken(securityToken, keyPairSupplier);
+            st.validate(minTokenLifetime, logger);
+            return st.getSecurityToken();
         } catch (Exception e) {
             throw new SecurityInfoNotReadyException(e.getMessage(), e);
         }

--- a/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
@@ -45,7 +45,7 @@ import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.security.auth.x500.X500Principal;
 
-import com.oracle.bmc.http.client.pki.Pem;
+import oracle.nosql.driver.iam.pki.Pem;
 import oracle.nosql.driver.Region;
 import oracle.nosql.driver.iam.CertificateSupplier.X509CertificateKeyPair;
 import com.fasterxml.jackson.core.JsonFactory;

--- a/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
@@ -9,11 +9,9 @@ package oracle.nosql.driver.iam;
 
 import static oracle.nosql.driver.util.CheckNull.requireNonNullIAE;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -40,19 +38,20 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.UUID;
 
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
+
+import com.oracle.bmc.http.client.pki.Pem;
 import oracle.nosql.driver.Region;
 import oracle.nosql.driver.iam.CertificateSupplier.X509CertificateKeyPair;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
-import org.bouncycastle.asn1.x500.RDN;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x500.style.BCStyle;
-import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 
 /**
  * @hidden
@@ -128,9 +127,9 @@ class Utils {
     }
 
     /**
-     * Creates a keyId from an {@link AuthenticationDetailsProvider}.
+     * Creates a keyId from an {@link UserAuthenticationProfileProvider}.
      *
-     * @param provider
+     * @param prov
      * @return The keyId used to sign requests
      */
     static String createKeyId(UserAuthenticationProfileProvider prov) {
@@ -202,17 +201,7 @@ class Utils {
      * @return A new input stream
      */
     static byte[] toByteArray(RSAPrivateKey key) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (JcaPEMWriter writer = new JcaPEMWriter(
-                 new OutputStreamWriter(baos, StandardCharsets.UTF_8))) {
-
-            writer.writeObject(key);
-            writer.flush();
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to write PEM object", e);
-        }
-
-        return baos.toByteArray();
+        return Pem.encoder().with(Pem.Format.LEGACY).encode(key);
     }
 
     /**
@@ -228,7 +217,7 @@ class Utils {
 
    /**
     * Base64 encodes a X509Certificate with no chunking.
-    * @param certificate The certificate
+    * @param keyPair The certificate
     * @return Base64 representation
     */
     static String base64EncodeNoChunking(X509CertificateKeyPair keyPair) {
@@ -241,7 +230,7 @@ class Utils {
 
     /**
      * Gets the fingerprint of a certificate using SHA-256.
-     * @param certificate the certificate
+     * @param keyPair the certificate
      * @return Fingerprint of the certificate
      * @throws Error if there is an error
      */
@@ -303,6 +292,9 @@ class Utils {
 
     /**
      * Get the tenant id from the given X509 certificate.
+     * See com.oracle.bmc.auth.internal.AuthUtils::getTenantIdFromCertificate
+     * for reference.
+     *
      * @param certificate the given certificate.
      * @return the tenant id.
      */
@@ -310,12 +302,11 @@ class Utils {
         requireNonNullIAE(certificate,
                           "Unable to get tenant id, certificate is null");
 
-        X500Name name = new X500Name(
-            certificate.getSubjectX500Principal().getName());
-
-        String tenantId = getValue(name, BCStyle.OU, "opc-tenant");
+        X500Principal principal = certificate.getSubjectX500Principal();
+        String name = principal.getName();
+        String tenantId = getValue(name, "OU", "opc-tenant");
         if (tenantId == null) {
-            tenantId = getValue(name, BCStyle.O, "opc-identity");
+            tenantId = getValue(name, "OU", "opc-identity");
         }
 
         if (tenantId != null) {
@@ -326,20 +317,34 @@ class Utils {
             "does not contain tenant id.");
     }
 
-    private static String getValue(X500Name name,
-                                   ASN1ObjectIdentifier id,
-                                   String key) {
-        String prefix = key + ":";
-        for (RDN rdn : name.getRDNs(id)) {
-            for (AttributeTypeAndValue typeAndValue : rdn.getTypesAndValues()) {
-                String value = typeAndValue.getValue().toString();
+    private static String getValue(String name, String type, String key) {
+        try {
+            final LdapName ldapName = new LdapName(name);
+            final String prefix = key + ":";
 
-                if (value.startsWith(prefix)) {
-                    return value.substring(prefix.length());
+            for (Rdn rdn : ldapName.getRdns()) {
+                final String rdnType = rdn.getType();
+                if (type.equalsIgnoreCase(rdnType)) {
+                    final Attribute attribute = rdn.toAttributes().get(type);
+                    if (attribute != null) {
+                        final NamingEnumeration<?> values = attribute.getAll();
+                        while (values.hasMore()) {
+                            final Object value = values.next();
+                            if (value != null) {
+                                final String text = value.toString().trim();
+                                if (text.startsWith(prefix)) {
+                                    return text.substring(prefix.length());
+                                }
+                            }
+                        }
+                    }
                 }
             }
+            return null;
+        } catch (NamingException e) {
+            throw new IllegalStateException(
+                "Error parsing the certificate name", e);
         }
-        return null;
     }
 
     static String readStream(InputStream inputStream)

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Eraser.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Eraser.java
@@ -1,0 +1,66 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import java.nio.ByteBuffer;
+
+/** Services for erasing the contents of mutable data structures such as arrays */
+class Eraser {
+
+    public static void erase(ByteBuffer byteBuffer) {
+        if (byteBuffer != null) {
+            if (byteBuffer.hasArray()) {
+                erase(byteBuffer.array());
+            } else {
+                eraseDirectBuffer(byteBuffer);
+            }
+        }
+    }
+
+    private static void eraseDirectBuffer(ByteBuffer byteBuffer) {
+        byteBuffer.clear();
+        int length = byteBuffer.capacity();
+        for (int i = 0; i < length; i++) {
+            byteBuffer.put(i, (byte) 0);
+        }
+    }
+
+    public static void erase(byte[] bytes) {
+        if (bytes != null) {
+            final int length = bytes.length;
+            /* zero out first character */
+            if (length > 0) {
+                bytes[0] = 0;
+            }
+            /* copy zeroed byte to all other bytes in buf, faster than naive iteration
+             * over each element in the array.
+             * Duplicates bytes in 2, 4, 8, etc increments
+             */
+            for (int pos = 1; pos < length; pos += pos) {
+                System.arraycopy(bytes, 0, bytes, pos, Math.min(length - pos, pos));
+            }
+        }
+    }
+
+    public static void erase(char[] chars) {
+        if (chars != null) {
+            final int length = chars.length;
+            /* zero out first character */
+            if (length > 0) {
+                chars[0] = 0;
+            }
+            /* copy zeroed byte to all other bytes in buf, faster than naive iteration
+             * over each element in the array.
+             * Duplicates bytes in 2, 4, 8, etc increments
+             */
+            for (int pos = 1; pos < length; pos += pos) {
+                System.arraycopy(chars, 0, chars, pos, Math.min(length - pos, pos));
+            }
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Hex.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Hex.java
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+abstract class Hex {
+    private Hex() {}
+
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+
+    static String encode(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+    static byte[] decode(final CharSequence hex) {
+        final int length = hex.length();
+        byte[] bytes = new byte[length / 2];
+        for (int i = 0; i < length; ++i) {
+            final int highNibble = Character.digit(hex.charAt(i), 16) << 4;
+            final int lowNibble = Character.digit(hex.charAt(++i), 16);
+            bytes[i / 2] = (byte) (highNibble + lowNibble);
+        }
+        return bytes;
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/OpenSslPbeSecretKeyFactory.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/OpenSslPbeSecretKeyFactory.java
@@ -1,0 +1,47 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/** Generates the derived key for OpenSSL style encryption for PKCS1 encoded private keys */
+class OpenSslPbeSecretKeyFactory {
+    private final MessageDigest digest;
+
+    OpenSslPbeSecretKeyFactory() {
+        this(digest("MD5"));
+    }
+
+    OpenSslPbeSecretKeyFactory(final MessageDigest digest) {
+        this.digest = digest;
+    }
+
+    private static MessageDigest digest(final String algorithmName) {
+        try {
+            return MessageDigest.getInstance(algorithmName);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    Key generateSecret(final PBEKeySpec pbeSpec) throws InvalidKeySpecException {
+        OpenSslPbeSecretKeyGenerator generator =
+                OpenSslPbeSecretKeyGenerator.builder()
+                        .password(pbeSpec.getPassword())
+                        .salt(pbeSpec.getSalt())
+                        .keyLength(pbeSpec.getKeyLength())
+                        .build();
+        final byte[] keyBytes = generator.generate();
+        return new SecretKeySpec(keyBytes, "OpenSSLPBKDF");
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/OpenSslPbeSecretKeyGenerator.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/OpenSslPbeSecretKeyGenerator.java
@@ -1,0 +1,127 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+/**
+ * Derives the secret key used for <a
+ * href="https://www.openssl.org/docs/man3.1/man3/EVP_BytesToKey.html">OpenSSL style encryption.</a>
+ *
+ * <ul>
+ *   <li>By default the message digest algorithm used is MD5 :(
+ *   <li>The iteration count is 1
+ *   <li>A digest of the password and a random 8 byte salt is produced
+ *   <li>The digest is repeatedly generated until sufficient bytes have been generated for the
+ *       specified key size
+ * </ul>
+ *
+ * @see <a
+ *     href="https://github.com/openssl/openssl/blob/4a6f70c03182b421d326831532edca32bcdb3fb1/crypto/evp/evp_key.c#L78">EVP_BytesToKey
+ *     source code</a>
+ */
+class OpenSslPbeSecretKeyGenerator {
+
+    private final MessageDigest digest;
+    private final byte[] password;
+    private final byte[] salt;
+
+    private final int keyLength;
+
+    private OpenSslPbeSecretKeyGenerator(Builder builder) {
+        digest = builder.digest;
+        password = builder.password;
+        salt = builder.salt;
+        keyLength = builder.keyLength;
+    }
+
+    private static byte[] toBytes(char[] chars) {
+        CharBuffer charBuffer = CharBuffer.wrap(chars);
+        ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(charBuffer);
+        byte[] bytes =
+                Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+        Eraser.erase(byteBuffer); // clear sensitive data
+        return bytes;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    byte[] generate() {
+        int bytesNeeded = keyLength / 8;
+        byte[] key = new byte[bytesNeeded];
+        int offset = 0;
+
+        for (; ; ) {
+            digest.update(password, 0, password.length);
+            digest.update(salt, 0, salt.length);
+
+            final byte[] digested = digest.digest();
+
+            int len = (bytesNeeded > digested.length) ? digested.length : bytesNeeded;
+            System.arraycopy(digested, 0, key, offset, len);
+            offset += len;
+
+            // check if we need any more
+            bytesNeeded -= len;
+            if (bytesNeeded == 0) {
+                break;
+            }
+
+            // do another round
+            digest.reset();
+        }
+
+        return key;
+    }
+
+    static final class Builder {
+        private MessageDigest digest;
+        private byte[] password;
+        private byte[] salt;
+        private int keyLength;
+
+        private Builder() {
+            try {
+                this.digest = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        Builder digest(MessageDigest digest) {
+            this.digest = digest;
+            return this;
+        }
+
+        Builder password(char[] password) {
+            this.password = toBytes(password);
+            return this;
+        }
+
+        Builder salt(byte[] salt) {
+            this.salt = salt;
+            return this;
+        }
+
+        Builder keyLength(int keyLength) {
+            this.keyLength = keyLength;
+            return this;
+        }
+
+        OpenSslPbeSecretKeyGenerator build() {
+            return new OpenSslPbeSecretKeyGenerator(this);
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Pem.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Pem.java
@@ -1,0 +1,1231 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+/**
+ * Services for working with PEM encoded private keys, public keys and certificates.
+ *
+ * <h3>Read a public key</h3>
+ *
+ * <pre>
+ * PublicKey readPublicKey(Path path) {
+ *  try (ReadableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.decoder()
+ *             .decodePublicKey(pem);
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>Read an unencrypted private key</h3>
+ *
+ * <pre>
+ * PrivateKey readPrivateKey(Path path) {
+ *  try (ReadableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.decoder()
+ *             .decodePrivateKey(pem);
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>Read an encrypted private key</h3>
+ *
+ * <pre>
+ * PrivateKey readPrivateKey(Path path, char[] passphrase) {
+ *  try (ReadableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.decoder()
+ *             .with(passphrase)
+ *             .decodePrivateKey(pem);
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>Write a public key</h3>
+ *
+ * <pre>
+ * void writePublicKey(Path path,final PublicKey publicKey) {
+ *  try (WritableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.encoder()
+ *             .write(pem,publicKey);
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>Write an unencrypted private key</h3>
+ *
+ * <pre>
+ * void writePrivateKey(Path path,final PrivateKey privateKey) {
+ *  try (WritableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.encoder()
+ *             .write(pem,privateKey);
+ *   }
+ * }
+ * </pre>
+ *
+ * <h3>Write an encrypted private key in PKCS1 format</h3>
+ *
+ * <pre>
+ * void writePkcs1PrivateKey(Path path,final PrivateKey privateKey, char[] passphrase) {
+ *  try (WritableByteChannel pem = Files.newByteChannel(path)) {
+ *   return Pem.encoder()
+ *             .with(Pem.Format.LEGACY)
+ *             .with(passphrase)
+ *             .write(pem,privateKey);
+ *   }
+ * }
+ * </pre>
+ */
+public abstract class Pem {
+
+    // Only RSA encryption is supported
+    private static final String KEY_PAIR_ALGORITHM = "RSA";
+    // Only X509 Certificates are supported
+    private static final String CERTIFICATE_TYPE = "X509";
+
+    private static final int PKCS8_PRIVATE_KEY_HEADER_SIZE = 26;
+    private static final int X509_PUBLIC_KEY_HEADER_SIZE = 24;
+    private static final Encoder ENCODER = new Encoder(Format.DEFAULT, null);
+    private static final Decoder DECODER = decoder(CERTIFICATE_TYPE, KEY_PAIR_ALGORITHM);
+
+    private Pem() {}
+
+    private static Decoder decoder(final String certificateType, final String keyPairAlgorithm) {
+
+        try {
+            CertificateFactory certificateFactory = CertificateFactory.getInstance(certificateType);
+            KeyFactory keyFactory = KeyFactory.getInstance(keyPairAlgorithm);
+            return new Decoder(certificateFactory, keyFactory, null);
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            throw new PemException(e);
+        }
+    }
+
+    /**
+     * Erase (zero out) the contents of a byte array
+     *
+     * @param bytes The byte array to erase
+     */
+    private static void erase(final byte[] bytes) {
+        Eraser.erase(bytes);
+    }
+
+    /**
+     * All Java private keys are PKCS8 encoded. This method converts them back to PKCS1 format, by
+     * stripping the PKCS8 header.
+     *
+     * @param pkcs8 encoded bytes
+     * @return PKCS1 encoded representation of the key
+     * @see <a href="https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem">ASN1
+     *     key structures in DER and PEM</a>
+     */
+    private static byte[] asPkcs1PrivateKey(byte[] pkcs8) {
+        return Arrays.copyOfRange(pkcs8, PKCS8_PRIVATE_KEY_HEADER_SIZE, pkcs8.length);
+    }
+
+    /**
+     * All Java public keys are X509 encoded. This method converts them back to PKCS1 format, by
+     * stripping the X509 header.
+     *
+     * @param x509 X509 encoded public key bytes
+     * @return PKCS1 encoded representation of the key
+     * @see <a href="https://tls.mbed.org/kb/cryptography/asn1-key-structures-in-der-and-pem">ASN1
+     *     key structures in DER and PEM</a>
+     */
+    private static byte[] asPkcs1PublicKey(byte[] x509) {
+        return Arrays.copyOfRange(x509, X509_PUBLIC_KEY_HEADER_SIZE, x509.length);
+    }
+
+    /**
+     * Concatenate two byte arrays
+     *
+     * @param first The first array
+     * @param second The second array
+     * @return The concatenated array
+     */
+    private static byte[] join(final byte[] first, final byte[] second) {
+        final byte[] bytes = new byte[first.length + second.length];
+        System.arraycopy(first, 0, bytes, 0, first.length);
+        System.arraycopy(second, 0, bytes, first.length, second.length);
+        return bytes;
+    }
+
+    /**
+     * Converts PKCS1 to X509 Public KeyInfo by adding an ASN.1 header to identify the algorithm
+     * used to encode the payload (PKCS1 supports RSA only, X509 supports different algorithms).
+     *
+     * @param pkcs1 PKCS1 encoded bytes
+     * @return X509 Public KeyInfo der encoded bytes
+     */
+    private static byte[] adaptPkcs1PublicKey(final byte[] pkcs1) {
+        final int pkcs1Length = pkcs1.length;
+        final int totalLength = pkcs1Length + 20;
+        // because extra 0x00 padding byte?
+        final int contentLength = pkcs1Length + 1;
+        final byte[] pkcs8Header =
+                new byte[] {
+                    0x30,
+                    (byte) 0x82,
+                    (byte) ((totalLength >> 8) & 0xff),
+                    (byte) (totalLength & 0xff),
+                    0x30,
+                    0xD,
+                    0x6,
+                    0x9,
+                    0x2A,
+                    (byte) 0x86,
+                    0x48,
+                    (byte) 0x86,
+                    (byte) 0xF7,
+                    0xD,
+                    0x1,
+                    0x1,
+                    0x1,
+                    0x5,
+                    0x0,
+                    0x3,
+                    (byte) 0x82,
+                    (byte) ((contentLength >> 8) & 0xff),
+                    (byte) (contentLength & 0xff),
+                    0x00
+                };
+        final byte[] pkcs8bytes = join(pkcs8Header, pkcs1);
+        return pkcs8bytes;
+    }
+
+    /**
+     * Converts PKCS1 to PKCS8 by adding an ASN.1 header to identify the algorithm used to encode
+     * the payload (PKCS1 supports RSA only, PKCS8 supports different algorithms).
+     *
+     * @param pkcs1 PKCS1 encoded bytes
+     * @return PKCS8 encoded bytes
+     */
+    private static byte[] adaptPkcs1PrivateKey(final byte[] pkcs1) {
+        final int pkcs1Length = pkcs1.length;
+        final int totalLength = pkcs1Length + 22;
+        final byte[] pkcs8Header =
+                new byte[] {
+                    0x30,
+                    (byte) 0x82,
+                    (byte) ((totalLength >> 8) & 0xff),
+                    (byte) (totalLength & 0xff),
+                    0x2,
+                    0x1,
+                    0x0,
+                    0x30,
+                    0xD,
+                    0x6,
+                    0x9,
+                    0x2A,
+                    (byte) 0x86,
+                    0x48,
+                    (byte) 0x86,
+                    (byte) 0xF7,
+                    0xD,
+                    0x1,
+                    0x1,
+                    0x1,
+                    0x5,
+                    0x0,
+                    0x4,
+                    (byte) 0x82,
+                    (byte) ((pkcs1Length >> 8) & 0xff),
+                    (byte) (pkcs1Length & 0xff)
+                };
+        final byte[] pkcs8bytes = join(pkcs8Header, pkcs1);
+        return pkcs8bytes;
+    }
+
+    private static byte[] encryptPkcs1(byte[] der, Encryption encryption) {
+        try (final Pkcs1EncryptedPrivateKeyInfo encryptedPrivateKeyInfo =
+                Pkcs1EncryptedPrivateKeyInfo.of(encryption)) {
+            return cryptPkcs1(
+                    Cipher.ENCRYPT_MODE, der, encryptedPrivateKeyInfo, encryption.passphrase());
+        }
+    }
+
+    private static byte[] cryptPkcs1(
+            int mode,
+            byte[] content,
+            Pkcs1EncryptedPrivateKeyInfo encryptedPrivateKeyInfo,
+            Passphrase passphrase) {
+        try {
+            final SecretKey secretKey = passphrase.map(encryptedPrivateKeyInfo::secretKey);
+            final Cipher cipher = Cipher.getInstance(encryptedPrivateKeyInfo.algorithmName());
+            cipher.init(mode, secretKey, encryptedPrivateKeyInfo.getAlgParameters());
+            final byte[] result = cipher.doFinal(content);
+            return result;
+        } catch (NoSuchAlgorithmException
+                | NoSuchPaddingException
+                | InvalidKeyException
+                | InvalidAlgorithmParameterException
+                | IllegalBlockSizeException
+                | BadPaddingException e) {
+            throw new PemEncryptionException(e);
+        }
+    }
+
+    /**
+     * Return an encoder that does not encrypt private keys and formats private keys in PKCS8, and
+     * public keys or certificates in X509.
+     *
+     * <p>To encode encrypted private keys call {@link Encoder#with(Encryption)}
+     *
+     * <p>To format private keys and public keys in PKCS1, call {@link Encoder#with(Format)} e.g.:
+     *
+     * <pre>
+     *     Pem.Encoder encoder = Pem.encoder().with(Format.LEGACY);
+     * </pre>
+     *
+     * @return Encoder instance
+     */
+    public static Encoder encoder() {
+        return ENCODER;
+    }
+
+    /**
+     * Return a decoder for certificates, public keys and unencrypted private keys.
+     *
+     * <p>To decode encrypted private keys call {@link Decoder#with(Passphrase)}.
+     *
+     * @return Decoder instance
+     */
+    public static Decoder decoder() {
+        return DECODER;
+    }
+
+    /**
+     * Denotes the specific syntax used for encoding public and private keys (Does not affect the
+     * encoding of certificates)
+     */
+    public enum Format {
+        /**
+         * Encodes the public key or private key in PKCS1 format e.g. a legacy private key starts
+         * with {@code -----BEGIN RSA PRIVATE KEY-----}
+         */
+        LEGACY,
+        /** Encodes private keys in PKCS8 format and public keys in X509 public key format */
+        DEFAULT
+    }
+
+    /** Denotes the type of content encoded in the PEM message */
+    enum Type {
+        PKCS1_PRIVATE_KEY("RSA PRIVATE KEY"),
+        PKCS1_ENCRYPTED_PRIVATE_KEY("RSA PRIVATE KEY"),
+        PKCS1_PUBLIC_KEY("RSA PUBLIC KEY"),
+        PKCS8_ENCRYPTED_PRIVATE_KEY("ENCRYPTED PRIVATE KEY"),
+        PKCS8_PRIVATE_KEY("PRIVATE KEY"),
+        X509_PUBLIC_KEY("PUBLIC KEY"),
+        X509_CERTIFICATE("CERTIFICATE");
+
+        static final Pattern PKCS1_ENCRYPTED_HEADER_PATTERN =
+                Pattern.compile(
+                        "Proc-Type:\\s+\\d+,ENCRYPTED\\nDEK-Info:\\s+([A-Z1-9-]+),([0123456789ABCDEFabcdef]+)\\n(.*)",
+                        Pattern.DOTALL | Pattern.MULTILINE);
+        private final String prefix;
+        private final String suffix;
+
+        Type(final String identifier) {
+            this.prefix = "-----BEGIN " + identifier + "-----";
+            this.suffix = "-----END " + identifier + "-----";
+        }
+
+        /**
+         * Determine the PEM encoding format used
+         *
+         * @param text The text encoded PEM data
+         * @return The matching {@link Type}
+         * @throws IllegalArgumentException if the text is not any of the supported PEM encodings
+         */
+        static Type typeOf(final Utf8 text) {
+            for (final Type type : Type.values()) {
+                if (text.contains(type.prefix) && text.contains(type.suffix)) {
+                    if (type == PKCS1_PRIVATE_KEY && isEncryptedPkcs1(text)) {
+                        return PKCS1_ENCRYPTED_PRIVATE_KEY;
+                    }
+                    return type;
+                }
+            }
+            return null;
+        }
+
+        private static boolean isEncryptedPkcs1(Utf8 text) {
+            final Utf8 content = PKCS1_PRIVATE_KEY.content(text);
+            final Matcher matcher = PKCS1_ENCRYPTED_HEADER_PATTERN.matcher(content);
+            return matcher.matches();
+        }
+
+        private String algorithmIdentifier(final Encryption encryption) {
+            return encryption.algorithm()
+                    + '-'
+                    + encryption.keySize()
+                    + '-'
+                    + encryption.blockMode();
+        }
+
+        // Encrypted PKCS1 private key header
+        private String pemHeader(final Encryption encryption) {
+            String header =
+                    "Proc-Type: 4,ENCRYPTED\n"
+                            + "DEK-Info: "
+                            + algorithmIdentifier(encryption)
+                            + ","
+                            + Hex.encode(encryption.iv())
+                            + "\n";
+            return header;
+        }
+
+        byte[] encode(byte[] payload, final Encryption encryption) {
+            final StringBuilder text = new StringBuilder();
+            text.append(prefix);
+            text.append('\n');
+            if (PKCS1_ENCRYPTED_PRIVATE_KEY == this) {
+                final String pemHeader = pemHeader(encryption);
+                text.append(pemHeader);
+
+                payload = encryptPkcs1(payload, encryption);
+            }
+            final String encoded = Base64.getEncoder().encodeToString(payload);
+            final int length = encoded.length();
+            final int lineLength = 64;
+            int start = 0;
+            int end = start + lineLength;
+            while (true) {
+                if (!(start < length)) break;
+                text.append(encoded, start, Math.min(length, end));
+                text.append('\n');
+                start = end;
+                end = start + lineLength;
+            }
+            text.append(suffix);
+            return text.toString().getBytes(StandardCharsets.UTF_8);
+        }
+
+        Utf8 content(final Utf8 text) {
+            final int startDecl = text.indexOf(prefix);
+            if (startDecl != -1) {
+                // search for -----END ?????----- delimiter
+                final int endDecl = text.indexOf(suffix, startDecl);
+                if (endDecl != -1) {
+                    final Utf8 content = text.subSequence(startDecl + prefix.length(), endDecl);
+                    return content.trim();
+                }
+            }
+            // didn't find a BEGIN, END  pair
+            throw new IllegalArgumentException();
+        }
+
+        byte[] payload(final Utf8 text) {
+            try (final Utf8 encodedText = content(text);
+                    final Utf8 base64 = encodedText.removeWhitespace()) {
+                final byte[] decoded = Base64.getDecoder().decode(base64.bytes());
+                if (this == PKCS1_PRIVATE_KEY) {
+                    return adaptPkcs1PrivateKey(decoded);
+                } else if (this == PKCS1_PUBLIC_KEY) {
+                    return adaptPkcs1PublicKey(decoded);
+                }
+                return decoded;
+            }
+        }
+
+        boolean isEncrypted() {
+            return this == PKCS1_ENCRYPTED_PRIVATE_KEY || this == PKCS8_ENCRYPTED_PRIVATE_KEY;
+        }
+    }
+
+    /**
+     * Holds a passphrase using a try-with-resources model to assure the passphrase plain-text is
+     * erased once it has been used
+     */
+    public interface Passphrase extends Sensitive {
+
+        /**
+         * An instance that represents the absence of a passphrase
+         *
+         * @return Passphrase instance
+         */
+        static Passphrase none() {
+            return NoPassphrase.instance();
+        }
+
+        /**
+         * Produce a Passphrase for the specified character array. The caller is responsible for
+         * erasing the contents of the supplied array.
+         *
+         * @param content The passphrase
+         * @return Passphrase instance
+         */
+        static Passphrase of(final char[] content) {
+            if (content == null) {
+                return none();
+            } else {
+                return CharacterPassphrase.of(content);
+            }
+        }
+
+        /** Must erase the contents of the passphrase */
+        @Override
+        void close();
+
+        /**
+         * Map the passphrase to an instance of the desired type
+         *
+         * @param mapper The mapping function
+         * @return The mapped instance
+         * @param <T> The instance type
+         */
+        <T> T map(Function<char[], T> mapper);
+    }
+
+    /** Configures how private keys are encrypted */
+    public static class Encryption implements Sensitive {
+        static final String SUPPORTED_ENCRYPTION_ALGORITHM = "AES";
+
+        private static final Encryption NONE =
+                new Encryption("NONE", 0, null, "NONE", Passphrase.none(), false);
+
+        private static final SecureRandom PRNG = new SecureRandom();
+        private final String algorithm;
+        private final int keySize;
+        private final byte[] iv;
+        private final String blockMode;
+        private final Passphrase passphrase;
+        private final boolean ownsPassphrase;
+
+        private Encryption(Builder builder) {
+            this(
+                    SUPPORTED_ENCRYPTION_ALGORITHM,
+                    builder.keySize,
+                    builder.iv,
+                    builder.blockMode,
+                    builder.passphrase,
+                    builder.ownsPassphrase);
+        }
+
+        public Encryption(
+                String algorithm,
+                int keySize,
+                byte[] iv,
+                String blockMode,
+                Passphrase passphrase,
+                boolean ownsPassphrase) {
+            this.algorithm = algorithm;
+            this.keySize = keySize;
+            this.iv = iv;
+            this.blockMode = blockMode;
+            this.passphrase = passphrase;
+            this.ownsPassphrase = ownsPassphrase;
+        }
+
+        /**
+         * Constant representing the absence of encryption
+         *
+         * @return Encryption instance
+         */
+        public static Encryption none() {
+            return NONE;
+        }
+
+        /**
+         * Build {@link Encryption} instances
+         *
+         * @return Builder instance
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @Override
+        public void close() {
+            if (ownsPassphrase && passphrase != null) {
+                passphrase.close();
+            }
+        }
+
+        /**
+         * The encryption algorithm
+         *
+         * @return Encryption algorithm name
+         */
+        public String algorithm() {
+            return algorithm;
+        }
+
+        /**
+         * The key size
+         *
+         * @return Key size in bits
+         */
+        public int keySize() {
+            return keySize;
+        }
+
+        /**
+         * The initialization vector
+         *
+         * @return Initialization vector
+         */
+        public byte[] iv() {
+            return iv;
+        }
+
+        /**
+         * The block mode
+         *
+         * @return The block mode name
+         */
+        public String blockMode() {
+            return blockMode;
+        }
+
+        /**
+         * The encryption passphrase
+         *
+         * @return The passphrase
+         */
+        public Passphrase passphrase() {
+            return passphrase;
+        }
+
+        /** Build {@link Encryption} instances */
+        public static final class Builder {
+            private int keySize;
+            private byte[] iv;
+            private String blockMode;
+            private Passphrase passphrase;
+            private boolean ownsPassphrase;
+
+            private transient SecureRandom entropy;
+
+            private Builder() {
+                keySize = 128;
+                blockMode = "CBC";
+                entropy = PRNG;
+            }
+
+            /**
+             * The encryption key-size in bits, defaults to 128
+             *
+             * @param keySize The key size in bits
+             * @return self
+             */
+            public Builder keySize(int keySize) {
+                this.keySize = keySize;
+                return this;
+            }
+
+            /**
+             * Configure the entropy source to use for generating an initialization vector, if none
+             * explicitly specified
+             *
+             * @param entropy The source of random bytes
+             * @return self
+             */
+            public Builder entropy(final SecureRandom entropy) {
+                Objects.requireNonNull(entropy);
+                this.entropy = entropy;
+                return this;
+            }
+
+            /**
+             * The initialization vector
+             *
+             * @param iv The initialization vector
+             * @return self
+             */
+            public Builder iv(byte[] iv) {
+                this.iv = iv;
+                return this;
+            }
+
+            /**
+             * The block mode, defaults to {@code CBC}
+             *
+             * @param blockMode The block mode
+             * @return self
+             */
+            public Builder blockMode(String blockMode) {
+                this.blockMode = blockMode;
+                return this;
+            }
+
+            /**
+             * The pass phrase
+             *
+             * @param passphrase The passphrase
+             * @return self
+             */
+            public Builder passphrase(Passphrase passphrase) {
+                this.passphrase = passphrase;
+                return this;
+            }
+
+            /**
+             * Indicate if this instance owns the passphrase (and therefore must close/erase it,
+             * when this instance is closed)
+             *
+             * @param ownsPassphrase If true the instance will own the passphrase
+             * @return self
+             */
+            public Builder ownsPassphrase(boolean ownsPassphrase) {
+                this.ownsPassphrase = ownsPassphrase;
+                return this;
+            }
+
+            /**
+             * Configure the passphrase from a character array. The passphrase will be erased when
+             * the {@link Encryption} instance is closed
+             *
+             * @param passphrase The pass phrase
+             * @return self
+             */
+            public Builder passphrase(final char[] passphrase) {
+                return passphrase(Passphrase.of(passphrase)).ownsPassphrase(true);
+            }
+
+            /**
+             * Build the {@link Encryption} instance. If an initialization vector has not been
+             * configured, then a random one is automatically generated
+             *
+             * @return Encryption instance
+             */
+            public Encryption build() {
+                // Generate an IV if none specified
+                if (iv == null) {
+                    iv = new byte[keySize / 8];
+                    entropy.nextBytes(iv);
+                }
+                return new Encryption(this);
+            }
+        }
+    }
+
+    /** Decodes PEM encoded text streams into the desired format */
+    public static class Decoder {
+        private final Passphrase passphrase;
+        private final CertificateFactory certificateFactory;
+        private final KeyFactory keyFactory;
+
+        private Decoder(
+                final CertificateFactory certificateFactory,
+                final KeyFactory keyFactory,
+                final Passphrase passphrase) {
+            this.certificateFactory = certificateFactory;
+            this.keyFactory = keyFactory;
+            // Ignore the 'none' passphrase
+            this.passphrase = passphrase == Passphrase.none() ? null : passphrase;
+        }
+
+        /**
+         * Produce a decoder configured to use the specified passphrase for encrypted private keys
+         *
+         * @param passphrase The passphrase or null if no encrypted private keys will be decoded
+         * @return Decoder instance
+         */
+        public Decoder with(final Passphrase passphrase) {
+            return new Decoder(certificateFactory, keyFactory, passphrase);
+        }
+
+        /**
+         * Decode an X509 certificate
+         *
+         * @param contents The PEM encoded form of the X509 certificate
+         * @return Certificate instance
+         */
+        public Certificate decodeCertificate(final String contents) {
+            try (final InputStream bytes =
+                    new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8))) {
+                return certificateFactory.generateCertificate(bytes);
+            } catch (IOException | CertificateException e) {
+                throw new PemException(e);
+            }
+        }
+
+        /**
+         * Decode an X509 certificate
+         *
+         * @param contents The PEM encoded form of the X509 certificate
+         * @return Certificate instance
+         */
+        public Certificate decodeCertificate(final ReadableByteChannel contents) {
+            try (final InputStream bytes = Channels.newInputStream(contents)) {
+                return certificateFactory.generateCertificate(bytes);
+            } catch (IOException | CertificateException e) {
+                throw new PemException(e);
+            }
+        }
+
+        /**
+         * Decode an X509 certificate chain
+         *
+         * @param contents The PEM encoded certificate chain
+         * @return Collection of Certificate instances
+         */
+        public Collection<? extends Certificate> decodeCertificateChain(final String contents) {
+            try (final InputStream bytes =
+                    new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8))) {
+                return certificateFactory.generateCertificates(bytes);
+            } catch (IOException | CertificateException e) {
+                throw new PemException(e);
+            }
+        }
+
+        /**
+         * Decode an X509 certificate chain
+         *
+         * @param contents The PEM encoded certificate chain
+         * @return Collection of Certificate instances
+         */
+        public Collection<? extends Certificate> decodeCertificateChain(
+                final ReadableByteChannel contents) {
+            try (final InputStream bytes = Channels.newInputStream(contents)) {
+                return certificateFactory.generateCertificates(bytes);
+            } catch (IOException | CertificateException e) {
+                throw new PemException(e.getMessage(), e);
+            }
+        }
+
+        private PrivateKey decodeUnencryptedPrivateKey(final Type type, final Utf8 content) {
+            try {
+                final byte[] der = type.payload(content);
+                try {
+                    final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(der);
+                    return keyFactory.generatePrivate(spec);
+                } finally {
+                    erase(der);
+                }
+            } catch (InvalidKeySpecException e) {
+                throw new PemException(e.getMessage(), e);
+            }
+        }
+
+        private PrivateKey decodeEncryptedPrivateKey(final Type type, final Utf8 content) {
+            if (passphrase == null) {
+                throw new PemEncryptedKeyException();
+            }
+            if (type == Type.PKCS1_ENCRYPTED_PRIVATE_KEY) {
+                return decodeEncryptedPkcs1PrivateKey(content);
+            } else {
+                return decodeEncryptedPkcs8PrivateKey(content);
+            }
+        }
+
+        private String algorithmName(EncryptedPrivateKeyInfo encryptedPrivateKeyInfo) {
+            final String pbeAlgName = encryptedPrivateKeyInfo.getAlgName();
+
+            // For PBES2 retrieve details of the specific pbe algorithm (PRF and ES) from the
+            // algorithm parameters
+            if (pbeAlgName.equals("PBES2") || pbeAlgName.equals("1.2.840.113549.1.5.13")) {
+                return encryptedPrivateKeyInfo.getAlgParameters().toString();
+            } else {
+                return pbeAlgName;
+            }
+        }
+
+        private PrivateKey decodeEncryptedPkcs8PrivateKey(Utf8 content) {
+            try {
+                final byte[] der = Type.PKCS8_ENCRYPTED_PRIVATE_KEY.payload(content);
+                try {
+                    // configure decryption of the DER payload
+                    final EncryptedPrivateKeyInfo encryptedPrivateKeyInfo =
+                            new EncryptedPrivateKeyInfo(der);
+                    final String algorithmName = algorithmName(encryptedPrivateKeyInfo);
+                    final SecretKeyFactory secretKeyFactory =
+                            SecretKeyFactory.getInstance(algorithmName);
+                    final SecretKey secretKey =
+                            secretKeyFactory.generateSecret(passphrase.map(PBEKeySpec::new));
+                    final Cipher cipher = Cipher.getInstance(algorithmName);
+                    cipher.init(
+                            Cipher.DECRYPT_MODE,
+                            secretKey,
+                            encryptedPrivateKeyInfo.getAlgParameters());
+
+                    // decrypt and generate the private key
+                    final PrivateKey privateKey =
+                            keyFactory.generatePrivate(encryptedPrivateKeyInfo.getKeySpec(cipher));
+                    return privateKey;
+                } finally {
+                    erase(der);
+                }
+            } catch (NoSuchAlgorithmException
+                    | InvalidKeySpecException
+                    | NoSuchPaddingException
+                    | InvalidAlgorithmParameterException
+                    | InvalidKeyException
+                    | IOException e) {
+                throw new PemEncryptionException(e);
+            }
+        }
+
+        private PrivateKey decodeEncryptedPkcs1PrivateKey(Utf8 content) {
+            try (final Pkcs1EncryptedPrivateKeyInfo encryptedPrivateKeyInfo =
+                    Pkcs1EncryptedPrivateKeyInfo.of(content)) {
+
+                final byte[] pkcs1 =
+                        cryptPkcs1(
+                                Cipher.DECRYPT_MODE,
+                                encryptedPrivateKeyInfo.encoded(),
+                                encryptedPrivateKeyInfo,
+                                passphrase);
+                try {
+                    final byte[] der = adaptPkcs1PrivateKey(pkcs1);
+                    try {
+                        final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(der);
+                        final PrivateKey privateKey = keyFactory.generatePrivate(spec);
+                        return privateKey;
+                    } finally {
+                        erase(der);
+                    }
+                } finally {
+                    erase(pkcs1);
+                }
+            } catch (InvalidKeySpecException e) {
+                throw new PemEncryptionException(e);
+            }
+        }
+
+        /**
+         * Decode a private key. The private key is sensitive data, the caller is responsible for
+         * ensuring the input stream is closed (and any backing storage is erased)
+         *
+         * @param bytes The PEM encoded private key as UTF-8 encoded byte stream
+         * @return PrivateKey instance
+         */
+        public PrivateKey decodePrivateKey(final ReadableByteChannel bytes) throws IOException {
+            try (final Utf8 content = Utf8.of(bytes)) {
+                return decodePrivateKey(content);
+            }
+        }
+
+        /**
+         * Decode a private key. The private key is sensitive data and must be provided as a byte
+         * array. The caller is responsible for erasing the byte array after use.
+         *
+         * @param contents The PEM encoded private key as UTF-8 encoded bytes
+         * @return PrivateKey instance
+         */
+        public PrivateKey decodePrivateKey(final byte[] contents) {
+            try (final Utf8 content = Utf8.of(contents)) {
+                return decodePrivateKey(content);
+            }
+        }
+
+        private PrivateKey decodePrivateKey(Utf8 content) {
+            final Type type = Type.typeOf(content);
+            if (type == null) {
+                throw new IllegalArgumentException("Private key must be in PEM format");
+            }
+            if (type.isEncrypted()) {
+                return decodeEncryptedPrivateKey(type, content);
+            } else {
+                return decodeUnencryptedPrivateKey(type, content);
+            }
+        }
+
+        /**
+         * Decode a public key
+         *
+         * @param contents The PEM encoded public key
+         * @return PublicKey instance
+         */
+        public PublicKey decodePublicKey(final String contents) {
+            try (final Utf8 content = Utf8.of(contents)) {
+                final Type type = Type.typeOf(content);
+                if (type != null) {
+                    final byte[] der = type.payload(content);
+                    final X509EncodedKeySpec spec = new X509EncodedKeySpec(der);
+                    return keyFactory.generatePublic(spec);
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            } catch (InvalidKeySpecException e) {
+                throw new PemException(e);
+            }
+        }
+
+        /**
+         * Decode a public key
+         *
+         * @param contents The PEM encoded public key
+         * @return PublicKey instance
+         */
+        public PublicKey decodePublicKey(final ReadableByteChannel contents) {
+            try (final Utf8 content = Utf8.of(contents)) {
+                final Type type = Type.typeOf(content);
+                if (type != null) {
+                    final byte[] der = type.payload(content);
+                    final X509EncodedKeySpec spec = new X509EncodedKeySpec(der);
+                    return keyFactory.generatePublic(spec);
+                } else {
+                    throw new IllegalArgumentException();
+                }
+            } catch (InvalidKeySpecException | IOException e) {
+                throw new PemException(e);
+            }
+        }
+    }
+
+    // Represents the absence of a passphrase
+    private static class NoPassphrase implements Passphrase {
+
+        private static final NoPassphrase INSTANCE = new NoPassphrase();
+
+        private NoPassphrase() {}
+
+        static NoPassphrase instance() {
+            return INSTANCE;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public <T> T map(Function<char[], T> mapper) {
+            return null;
+        }
+    }
+
+    private static class CharacterPassphrase implements Passphrase {
+        private final char[] content;
+
+        private CharacterPassphrase(final char[] content) {
+            this.content = content;
+        }
+
+        static CharacterPassphrase of(final char[] content) {
+            return new CharacterPassphrase(Arrays.copyOf(content, content.length));
+        }
+
+        @Override
+        public void close() {
+            // erase the array
+            for (int i = 0; i < content.length; ++i) {
+                content[i] = 0;
+            }
+        }
+
+        @Override
+        public <T> T map(Function<char[], T> mapper) {
+            return mapper.apply(content);
+        }
+    }
+
+    /** Encode certificates, public keys and private keys into PEM encoded format */
+    public static class Encoder {
+
+        private final Encryption encryption;
+        private final Format format;
+
+        private Encoder(final Format format, final Encryption encryption) {
+            this.format = format;
+            this.encryption = encryption == Encryption.none() ? null : encryption;
+        }
+
+        /**
+         * Configure a new instance with the specified PKCS format. Note that the format applies to
+         * private and public keys only. Certificates always use X509 PEM encoding.
+         *
+         * @param format The encoding format for public and private keys
+         * @return Encoder instance
+         */
+        public Encoder with(final Format format) {
+            return new Encoder(format, encryption);
+        }
+
+        /**
+         * Configure an encoder to produce encrypted private keys.
+         *
+         * <p>Encryption does not apply to public keys or certificates
+         *
+         * @param encryption The encryption configuration, or null if no encryption is required
+         * @return Encoder instance
+         */
+        public Encoder with(final Encryption encryption) {
+            return new Encoder(format, encryption);
+        }
+
+        /**
+         * Configure an encoder to produce encrypted private keys.
+         *
+         * <p>Encryption does not apply to public keys or certificates
+         *
+         * @param passphrase The encryption passphrase, or null if no encryption is required
+         * @return Encoder instance
+         */
+        public Encoder with(final Passphrase passphrase) {
+            if (passphrase == null) {
+                return with(Encryption.none());
+            } else {
+                final Encryption encryption = Encryption.builder().passphrase(passphrase).build();
+                return with(encryption);
+            }
+        }
+
+        /**
+         * Render a public key in PEM format using PKCS1
+         *
+         * @param publicKey The public key
+         * @return PEM encoding of the public key in PKCS1 format
+         */
+        public String encode(final PublicKey publicKey) {
+            final byte[] der = publicKey.getEncoded();
+            if (format == Format.DEFAULT) {
+                return Text.of(Type.X509_PUBLIC_KEY.encode(der, null));
+            } else {
+                final byte[] payload = asPkcs1PublicKey(der);
+                return Text.of(Type.PKCS1_PUBLIC_KEY.encode(payload, null));
+            }
+        }
+
+        /**
+         * Render a certificate in PEM format
+         *
+         * @param certificate The certificate
+         * @return PEM encoding of the certificate
+         */
+        public String encode(final Certificate certificate) {
+            try {
+                final byte[] payload = certificate.getEncoded();
+                return Text.of(Type.X509_CERTIFICATE.encode(payload, null));
+            } catch (CertificateEncodingException e) {
+                throw new PemException(e);
+            }
+        }
+
+        /**
+         * Render a certificate chain in PEM format
+         *
+         * @param certificates The certificates
+         * @return PEM encoding of the certificate chain
+         */
+        public String encode(final Iterable<? extends Certificate> certificates) {
+            final StringBuilder text = new StringBuilder();
+            final Iterator<? extends Certificate> items = certificates.iterator();
+            while (items.hasNext()) {
+                final Certificate certificate = items.next();
+                text.append(encode(certificate));
+                if (items.hasNext()) {
+                    text.append('\n');
+                }
+            }
+            return text.toString();
+        }
+
+        /**
+         * Render a private key in PEM format. The private key is sensitive data and is returned as
+         * a byte array. The caller is responsible for erasing the byte array after use.
+         *
+         * @param privateKey The private key
+         * @return The PEM encoded private key as UTF-8 encoded bytes
+         */
+        public byte[] encode(final PrivateKey privateKey) {
+            final byte[] der = privateKey.getEncoded();
+
+            if (encryption == null) {
+                if (format == Format.DEFAULT) {
+                    return Type.PKCS8_PRIVATE_KEY.encode(der, null);
+                } else {
+                    final byte[] payload = asPkcs1PrivateKey(der);
+                    return Type.PKCS1_PRIVATE_KEY.encode(payload, null);
+                }
+            } else {
+                if (format == Format.DEFAULT) {
+                    return Type.PKCS8_ENCRYPTED_PRIVATE_KEY.encode(der, encryption);
+                } else {
+                    final byte[] payload = asPkcs1PrivateKey(der);
+                    return Type.PKCS1_ENCRYPTED_PRIVATE_KEY.encode(payload, encryption);
+                }
+            }
+        }
+
+        /**
+         * Write a private key to a byte stream
+         *
+         * @param output The byte stream
+         * @param privateKey The private key
+         * @throws IOException if an error occurs writing to the stream
+         */
+        public WritableByteChannel write(
+                final WritableByteChannel output, final PrivateKey privateKey) throws IOException {
+            final ByteBuffer buffer = ByteBuffer.wrap(encode(privateKey));
+            try {
+                output.write(buffer);
+            } finally {
+                Eraser.erase(buffer);
+            }
+            return output;
+        }
+
+        /**
+         * Write a public key to a byte stream
+         *
+         * @param output The byte stream
+         * @param publicKey The public key
+         * @throws IOException if an error occurs writing to the stream
+         */
+        public WritableByteChannel write(
+                final WritableByteChannel output, final PublicKey publicKey) throws IOException {
+            final ByteBuffer buffer = ByteBuffer.wrap(Text.bytes(encode(publicKey)));
+            output.write(buffer);
+            return output;
+        }
+
+        /**
+         * Write a certificate to a byte stream
+         *
+         * @param output The byte stream
+         * @param certificate The certificate
+         * @throws IOException if an error occurs writing to the stream
+         */
+        public WritableByteChannel write(
+                final WritableByteChannel output, final Certificate certificate)
+                throws IOException {
+            final ByteBuffer buffer = ByteBuffer.wrap(Text.bytes(encode(certificate)));
+            output.write(buffer);
+            return output;
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/PemEncryptedKeyException.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/PemEncryptedKeyException.java
@@ -1,0 +1,14 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+public class PemEncryptedKeyException extends PemEncryptionException {
+    PemEncryptedKeyException() {
+        super("Private Key is encrypted, but no passphrase configured");
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/PemEncryptionException.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/PemEncryptionException.java
@@ -1,0 +1,19 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+public class PemEncryptionException extends PemException {
+
+    PemEncryptionException(Throwable cause) {
+        super(cause);
+    }
+
+    PemEncryptionException(final String message) {
+        super(message);
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/PemException.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/PemException.java
@@ -1,0 +1,23 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+public class PemException extends IllegalStateException {
+
+    PemException(final String message) {
+        this(message, null);
+    }
+
+    PemException(final Throwable cause) {
+        this(null, cause);
+    }
+
+    PemException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Pkcs1EncryptedPrivateKeyInfo.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Pkcs1EncryptedPrivateKeyInfo.java
@@ -1,0 +1,172 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class Pkcs1EncryptedPrivateKeyInfo implements AutoCloseable {
+    private static final Pattern PKCS1_ALGORITHM_PATTERN = Pattern.compile("(...)-(...)-(...)");
+
+    private final String transformation;
+    private final int keySize;
+    private final AlgorithmParameterSpec algParamSpec;
+    private final byte[] salt;
+    private final byte[] encoded;
+
+    private Pkcs1EncryptedPrivateKeyInfo(Builder builder) {
+        transformation = builder.transformation;
+        keySize = builder.keySize;
+        encoded = builder.encoded;
+        final byte[] iv = builder.iv;
+        salt = builder.salt == null ? Arrays.copyOf(iv, 8) : builder.salt;
+        algParamSpec = new IvParameterSpec(builder.iv);
+    }
+
+    static Pkcs1EncryptedPrivateKeyInfo of(final Pem.Encryption encryption) {
+        final String transformation =
+                transformation(encryption.algorithm(), encryption.blockMode());
+        final int keySize = encryption.keySize();
+        final byte[] iv = encryption.iv();
+        return builder().transformation(transformation).keySize(keySize).iv(iv).build();
+    }
+
+    private static String transformation(final String algorithmName, final String algorithmMode) {
+        String blockMode = "CBC";
+        String padding = "PKCS5Padding";
+
+        // Figure out block mode and padding.
+        if ("CFB".equals(algorithmMode)) {
+            blockMode = "CFB";
+            padding = "NoPadding";
+        }
+        if ("ECB".equals(algorithmMode)) {
+            blockMode = "ECB";
+        }
+        if ("OFB".equals(algorithmMode)) {
+            blockMode = "OFB";
+            padding = "NoPadding";
+        }
+
+        final String transformation = algorithmName + "/" + blockMode + "/" + padding;
+
+        return transformation;
+    }
+
+    static Pkcs1EncryptedPrivateKeyInfo of(final Utf8 content) {
+        try (final Utf8 payload = Pem.Type.PKCS1_ENCRYPTED_PRIVATE_KEY.content(content)) {
+            final Matcher matcher = Pem.Type.PKCS1_ENCRYPTED_HEADER_PATTERN.matcher(payload);
+            if (matcher.matches()) {
+                final String algorithm = matcher.group(1);
+                final byte[] ivBytes = Hex.decode(matcher.group(2));
+                final String base64 = matcher.group(3).replaceAll("\\s+", "");
+                final Matcher algorithmMatcher = PKCS1_ALGORITHM_PATTERN.matcher(algorithm);
+                if (algorithmMatcher.matches()) {
+                    final String algorithmName = algorithmMatcher.group(1);
+                    final int keySize = Integer.parseInt(algorithmMatcher.group(2));
+                    final String algorithmMode = algorithmMatcher.group(3);
+
+                    final String transformation = transformation(algorithmName, algorithmMode);
+                    byte[] encoded = Base64.getDecoder().decode(base64);
+                    return builder()
+                            .transformation(transformation)
+                            .keySize(keySize)
+                            .iv(ivBytes)
+                            .encoded(encoded)
+                            .build();
+                }
+            }
+            throw new PemException(new IllegalArgumentException());
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    SecretKey secretKey(final char[] passphrase) {
+        try {
+            final PBEKeySpec spec = new PBEKeySpec(passphrase, salt, 1, keySize);
+            final OpenSslPbeSecretKeyFactory keyFactory = new OpenSslPbeSecretKeyFactory();
+
+            final byte[] key = keyFactory.generateSecret(spec).getEncoded();
+
+            return new SecretKeySpec(key, Pem.Encryption.SUPPORTED_ENCRYPTION_ALGORITHM);
+        } catch (InvalidKeySpecException e) {
+            throw new PemException(e);
+        }
+    }
+
+    String algorithmName() {
+        return transformation;
+    }
+
+    AlgorithmParameterSpec getAlgParameters() {
+        return algParamSpec;
+    }
+
+    byte[] encoded() {
+        return encoded;
+    }
+
+    @Override
+    public void close() {
+        Eraser.erase(encoded);
+    }
+
+    static final class Builder {
+        private String transformation;
+        private int keySize;
+
+        private byte[] iv;
+        private byte[] salt;
+        private byte[] encoded;
+
+        private Builder() {
+            transformation = "AES/CBC/PKCS5Padding";
+            keySize = 128;
+        }
+
+        public Builder transformation(String transformation) {
+            this.transformation = transformation;
+            return this;
+        }
+
+        public Builder keySize(int keySize) {
+            this.keySize = keySize;
+            return this;
+        }
+
+        public Builder salt(byte[] salt) {
+            this.salt = salt;
+            return this;
+        }
+
+        public Builder iv(byte[] iv) {
+            this.iv = iv;
+            return this;
+        }
+
+        public Builder encoded(byte[] encoded) {
+            this.encoded = encoded;
+            return this;
+        }
+
+        public Pkcs1EncryptedPrivateKeyInfo build() {
+            return new Pkcs1EncryptedPrivateKeyInfo(this);
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Sensitive.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Sensitive.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+/**
+ * Denotes a type which holds sensitive data and must be erased once it has been used.
+ *
+ * <h3>Usage Model</h3>
+ *
+ * Use the try-with-resources idiom to assure the sensitive data is erased after use:
+ *
+ * <pre>
+ *     try ( Sensitive sensitive = ... ) {
+ *         // use the sensitive data
+ *         ...
+ *     }
+ * </pre>
+ */
+interface Sensitive extends AutoCloseable {
+    /** Must erase the contents of the passphrase */
+    @Override
+    void close();
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Text.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Text.java
@@ -1,0 +1,86 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static oracle.nosql.driver.iam.pki.Eraser.erase;
+
+abstract class Text {
+
+    private Text() {}
+
+    static String of(byte[] utf8) {
+        if (utf8 == null) {
+            return null;
+        } else {
+            return new String(utf8, StandardCharsets.UTF_8);
+        }
+    }
+
+    static String of(Utf8 utf8) {
+        if (utf8 == null) {
+            return null;
+        } else {
+            return of(utf8.bytes());
+        }
+    }
+
+    static byte[] bytes(String text) {
+        if (text == null) {
+            return null;
+        } else {
+            return text.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    static char[] chars(final byte[] content) {
+        final ByteBuffer bytes = ByteBuffer.wrap(content);
+        final CharBuffer buffer = StandardCharsets.UTF_8.decode(bytes);
+
+        final char[] buf = buffer.array();
+        final int position = buffer.position();
+        final int limit = buffer.limit();
+        final int offset = buffer.arrayOffset();
+        if (offset == 0 && position == 0 && limit == buf.length) {
+            // no copy needed
+            return buf;
+        } else {
+            // must copy subsection of backing array
+            final char[] chars = Arrays.copyOfRange(buf, offset + position, offset + limit);
+            Eraser.erase(buf);
+            return chars;
+        }
+    }
+
+    static byte[] bytes(final CharBuffer text) {
+        if (text == null) {
+            return null;
+        } else {
+            final CharBuffer chars = text.asReadOnlyBuffer();
+            final ByteBuffer buffer = StandardCharsets.UTF_8.encode(chars);
+            final byte[] buf = buffer.array();
+
+            final int position = buffer.position();
+            final int limit = buffer.limit();
+            final int offset = buffer.arrayOffset();
+            if (offset == 0 && position == 0 && limit == buf.length) {
+                // no copy needed
+                return buf;
+            } else {
+                // must copy subsection of backing array
+                final byte[] bytes = Arrays.copyOfRange(buf, offset + position, offset + limit);
+                Eraser.erase(buf);
+                return bytes;
+            }
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/Utf8.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/Utf8.java
@@ -1,0 +1,264 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam.pki;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Mutable byte buffer for UTF-8 encoded text. When the text has been consumed it MUST be erased via
+ * {@link #close()} to avoid leaking sensitive data on the heap.
+ */
+interface Utf8 extends CharSequence, Sensitive {
+
+    /**
+     * Wrap a mutable byte array. Does not claim ownership of the array. Caller is responsible for
+     * erasing the byte array
+     *
+     * @param bytes The bytes to wrap
+     * @return Utf8 instance
+     */
+    static Utf8 of(byte[] bytes) {
+        return new Chars(CharBuffer.wrap(Text.chars(bytes)));
+    }
+
+    /**
+     * Buffer the contents of a stream into a Utf8 buffer. The contents will be erased when the
+     * buffer is closed.
+     *
+     * @param content The content to buffer
+     * @return Utf8 buffer
+     * @throws IOException
+     */
+    static Utf8 of(ReadableByteChannel content) throws IOException {
+        try (final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                final WritableByteChannel sink = Channels.newChannel(bytes)) {
+            final ByteBuffer buffer = ByteBuffer.allocate(4096);
+            while (content.read(buffer) != -1) {
+                buffer.flip();
+                while (buffer.hasRemaining()) {
+                    /* write() might not write all of the bytes in a single pass */
+                    sink.write(buffer);
+                }
+                buffer.clear();
+            }
+            buffer.flip();
+            while (buffer.hasRemaining()) {
+                sink.write(buffer);
+            }
+            final byte[] buffered = bytes.toByteArray();
+            try {
+                return Utf8.of(buffered);
+            } finally {
+                Eraser.erase(buffer);
+                Eraser.erase(buffered);
+            }
+        }
+    }
+
+    /**
+     * Wrap an immutable String.
+     *
+     * @param text The string to wrap
+     * @return Utf8 instance
+     */
+    static Utf8 of(final String text) {
+        return new Wrapper(text);
+    }
+
+    @Override
+    Utf8 subSequence(int start, int end);
+
+    default boolean contains(final String text) {
+        return indexOf(text) != -1;
+    }
+
+    default int indexOf(String text) {
+        return indexOf(text, 0);
+    }
+
+    default int indexOf(String text, int offset) {
+        int fromIndex = offset;
+        int sourceCount = length();
+        int targetCount = text.length();
+        int targetOffset = 0;
+        int sourceOffset = 0;
+        if (fromIndex >= sourceCount) {
+            return (targetCount == 0 ? sourceCount : -1);
+        }
+        if (fromIndex < 0) {
+            fromIndex = 0;
+        }
+        if (targetCount == 0) {
+            return fromIndex;
+        }
+
+        char first = text.charAt(targetOffset);
+        int max = sourceOffset + (sourceCount - targetCount);
+
+        for (int i = sourceOffset + fromIndex; i <= max; i++) {
+            /* Look for first character. */
+            if (charAt(i) != first) {
+                while (++i <= max && charAt(i) != first) ;
+            }
+
+            /* Found first character, now look at the rest of v2 */
+            if (i <= max) {
+                int j = i + 1;
+                int end = j + targetCount - 1;
+                for (int k = targetOffset + 1; j < end && charAt(j) == text.charAt(k); j++, k++) ;
+
+                if (j == end) {
+                    /* Found whole string. */
+                    return i - sourceOffset;
+                }
+            }
+        }
+        return -1;
+    }
+
+    default Utf8 trim() {
+        int len = length();
+        int st = 0;
+
+        while ((st < len) && (charAt(st) <= ' ')) {
+            st++;
+        }
+        while ((st < len) && (charAt(len - 1) <= ' ')) {
+            len--;
+        }
+        return ((st > 0) || (len < length())) ? subSequence(st, len) : this;
+    }
+
+    byte[] bytes();
+
+    /**
+     * Strip all whitespace characters in the text
+     *
+     * @return Text with all whitespace removed
+     */
+    Utf8 removeWhitespace();
+
+    class Wrapper implements Utf8 {
+
+        private final String target;
+
+        private Wrapper(final String target) {
+            this.target = target;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public int length() {
+            return target.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return target.charAt(index);
+        }
+
+        @Override
+        public Utf8 subSequence(int start, int end) {
+            return Utf8.of(target.substring(start, end));
+        }
+
+        @Override
+        public int indexOf(String text, int offset) {
+            return target.indexOf(text, offset);
+        }
+
+        @Override
+        public Utf8 trim() {
+            return Utf8.of(target.trim());
+        }
+
+        @Override
+        public byte[] bytes() {
+            return Text.bytes(target);
+        }
+
+        @Override
+        public Utf8 removeWhitespace() {
+            return Utf8.of(target.replaceAll("\\s+", ""));
+        }
+    }
+
+    /** Byte array backed Utf8 */
+    class Chars implements Utf8 {
+        private final transient CharBuffer text;
+
+        private Chars(final CharBuffer text) {
+            this.text = text;
+        }
+
+        @Override
+        public void close() {
+            Eraser.erase(text.array());
+        }
+
+        @Override
+        public int length() {
+            return text.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            final char c = text.charAt(index);
+            return c;
+        }
+
+        @Override
+        public Utf8 subSequence(int beginIndex, int endIndex) {
+            if (beginIndex == 0 && endIndex == text.length()) {
+                return this;
+            } else {
+                final CharBuffer subSequence = text.subSequence(beginIndex, endIndex);
+                return new Chars(copyOf(subSequence));
+            }
+        }
+
+        private CharBuffer copyOf(CharBuffer existing) {
+            final CharBuffer copy = CharBuffer.allocate(existing.remaining());
+            final CharBuffer temp = existing.asReadOnlyBuffer();
+            copy.put(temp);
+            copy.flip();
+            return copy;
+        }
+
+        public byte[] bytes() {
+            return Text.bytes(text);
+        }
+
+        @Override
+        public Utf8 removeWhitespace() {
+            final CharBuffer modified = CharBuffer.allocate(text.remaining());
+
+            for (int i = 0; i < text.remaining(); ++i) {
+                final char c = text.charAt(i);
+                if (c > ' ') {
+                    modified.put(c);
+                }
+            }
+            modified.flip();
+            return new Chars(modified);
+        }
+
+        @Override
+        public String toString() {
+            return text.toString();
+        }
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/iam/pki/package-info.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/pki/package-info.java
@@ -1,0 +1,10 @@
+/*-
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+/**
+ * This package is the clone of com.oracle.bmc.http.client.pki in oci-java-sdk
+ */
+package oracle.nosql.driver.iam.pki;

--- a/driver/src/test/java/oracle/nosql/driver/DriverTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/DriverTestBase.java
@@ -8,40 +8,25 @@
 package oracle.nosql.driver;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.StringWriter;
-import java.math.BigInteger;
 import java.net.HttpURLConnection;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.Provider;
+import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.interfaces.RSAPublicKey;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Base64.Encoder;
-import java.util.Date;
 
+import com.oracle.bmc.http.client.pki.Pem;
 import com.sun.net.httpserver.HttpExchange;
-
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMEncryptor;
-import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
-import org.bouncycastle.openssl.jcajce.JcePEMEncryptorBuilder;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 /**
  * A common base for driver tests. It is empty at this point but may
@@ -162,27 +147,19 @@ public class DriverTestBase {
         KeyPairGenerator keygen = KeyPairGenerator.getInstance("RSA");
         keygen.initialize(2048);
         KeyPair keypair = keygen.generateKeyPair();
-        PEMEncryptor pemEncryptor = null;
-
-        if (passphrase != null) {
-            JcePEMEncryptorBuilder builder =
-                new JcePEMEncryptorBuilder("DES-EDE3-CBC");
-            builder.setSecureRandom(new SecureRandom());
-            builder.setProvider(getBouncyCastleProvider());
-            pemEncryptor = builder.build(passphrase);
-        }
 
         File keyFile = new File(getTestDir(), name);
-        try (FileWriter privateWrite = new FileWriter(keyFile);
-            JcaPEMWriter privatePemWriter = new JcaPEMWriter(privateWrite); ) {
+        if (!keyFile.exists()) {
+            keyFile.createNewFile();
+        }
+        try (WritableByteChannel pem = Files.newByteChannel(
+                keyFile.toPath(), StandardOpenOption.WRITE)) {
+            Pem.Encoder encoder = (passphrase == null) ?
+                Pem.encoder().with(Pem.Format.LEGACY) :
+                Pem.encoder().with(Pem.Format.LEGACY)
+                    .with(Pem.Passphrase.of(passphrase));
 
-            if (pemEncryptor != null) {
-                privatePemWriter
-                    .writeObject(keypair.getPrivate(), pemEncryptor);
-            }
-            else {
-                privatePemWriter.writeObject(keypair.getPrivate());
-            }
+            encoder.write(pem, keypair.getPrivate());
         }
         return keyFile.getAbsolutePath();
     }
@@ -197,48 +174,49 @@ public class DriverTestBase {
     protected static KeyPairInfo generateKeyPair()
         throws Exception {
 
-        KeyPairGenerator keygen = KeyPairGenerator.getInstance("RSA");
-        keygen.initialize(2048);
-        KeyPair keypair = keygen.generateKeyPair();
+        final File keyStoreFile = new File(getTestDir(), "keystore");
+        final String pwd = "123456";
+        final String alias = "test";
 
-        JcaPKCS8Generator gen = new JcaPKCS8Generator(keypair.getPrivate(),
-                                                      null);
-        StringWriter sw = new StringWriter();
-        try (JcaPEMWriter pw = new JcaPEMWriter(sw)) {
-            pw.writeObject(gen.generate());
+        String[] keyStoreCmds = new String[] {
+            "keytool",
+            "-genkeypair",
+            "-keystore", keyStoreFile.getAbsolutePath(),
+            "-storetype", "PKCS12",
+            "-storepass", pwd,
+            "-keypass", pwd,
+            "-alias", alias,
+            "-dname", "OU=opc-tenant:TestTenant",
+            "-keyAlg", "RSA",
+            "-keysize", 2048 + "",
+            "-validity", 365 + ""};
+
+        Process proc = Runtime.getRuntime().exec(keyStoreCmds);
+        boolean done = false;
+        int returnCode = 0;
+        while (!done) {
+            returnCode = proc.waitFor();
+            done = true;
         }
 
-        String key = sw.toString();
-
-        X500Name name = new X500Name("OU=opc-tenant:TestTenant");
-        SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo
-            .getInstance(keypair.getPublic().getEncoded());
-        Date start = new Date();
-        Date until = Date.from(LocalDate.now().plus(3650, ChronoUnit.DAYS)
-                         .atStartOfDay().toInstant(ZoneOffset.UTC));
-        X509v3CertificateBuilder builder = new X509v3CertificateBuilder(
-            name,
-            new BigInteger(10, new SecureRandom()),
-            start,
-            until,
-            name,
-            subPubKeyInfo
-        );
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
-            .setProvider(new BouncyCastleProvider())
-            .build(keypair.getPrivate());
-        X509CertificateHolder holder = builder.build(signer);
-
-        Certificate cert = new JcaX509CertificateConverter()
-            .setProvider(new BouncyCastleProvider()).getCertificate(holder);
-
-        sw = new StringWriter();
-        try (JcaPEMWriter pw = new JcaPEMWriter(sw)) {
-            pw.writeObject(cert);
+        if (returnCode != 0) {
+            throw new IllegalStateException(
+                "Error generating keystore:" + returnCode);
         }
-        String certString = sw.toString();
 
-        return new KeyPairInfo(key, certString, keypair);
+        KeyStore keystore = KeyStore.getInstance("PKCS12");
+        keystore.load(new FileInputStream(keyStoreFile), pwd.toCharArray());
+        KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry)
+            keystore.getEntry(
+                alias, new KeyStore.PasswordProtection(pwd.toCharArray()));
+        PrivateKey pk = entry.getPrivateKey();
+        Certificate cert = entry.getCertificate();
+        KeyPair keyPair = new KeyPair(cert.getPublicKey(), pk);
+
+        return new KeyPairInfo(
+            new String(Pem.encoder().with(Pem.Format.LEGACY).encode(pk)),
+            Pem.encoder().with(Pem.Format.LEGACY).encode(cert),
+            keyPair);
     }
 
     /**
@@ -252,15 +230,6 @@ public class DriverTestBase {
             throw new IllegalArgumentException(
                 content + " doesn't contains " + expected);
         }
-    }
-
-    private static Provider getBouncyCastleProvider()
-        throws Exception {
-
-        Class<?> providerClass = Class.forName(
-            "org.bouncycastle.jce.provider.BouncyCastleProvider");
-        return (Provider)providerClass
-            .getDeclaredConstructor().newInstance();
     }
 
     protected static class KeyPairInfo {

--- a/driver/src/test/java/oracle/nosql/driver/DriverTestBase.java
+++ b/driver/src/test/java/oracle/nosql/driver/DriverTestBase.java
@@ -25,7 +25,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.Base64.Encoder;
 
-import com.oracle.bmc.http.client.pki.Pem;
+import oracle.nosql.driver.iam.pki.Pem;
 import com.sun.net.httpserver.HttpExchange;
 
 /**

--- a/driver/src/test/java/oracle/nosql/driver/iam/InstancePrincipalsProviderTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/iam/InstancePrincipalsProviderTest.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import oracle.nosql.driver.DriverTestBase;
 import oracle.nosql.driver.FreePortLocator;
 import oracle.nosql.driver.NoSQLHandleConfig;
-import oracle.nosql.driver.Region;
 import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.iam.CertificateSupplier.DefaultCertificateSupplier;
 import oracle.nosql.driver.iam.CertificateSupplier.URLResourceDetails;
@@ -95,6 +94,7 @@ public class InstancePrincipalsProviderTest extends DriverTestBase {
     @AfterClass
     public static void staticTearDown() {
         server.stop(0);
+        clearTestDirectory();
     }
 
     @Before


### PR DESCRIPTION
- replaced the bouncy castle libraries with PEM utility classes from oci-java-sdk written in standard Java JCE APIs due to the CVE problems found in security scans.
- changed the exception thrown in Instance/Resource/OKE principal providers for invalid security token from IllegalArgumentException to SecurityInfoNotReadyException. We have seen a security token issued by IAM failed the local token validation in production region, the only action to take is to retry in this case.