### PR TITLE
reverted VirtualScan simplification and added join-related info to VirtualScan

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
@@ -108,6 +108,8 @@ public class NsonProtocol {
     public static String VIRTUAL_SCANS = "vssa";
     public static String VIRTUAL_SCAN_SID = "vssid";
     public static String VIRTUAL_SCAN_PID = "vspid";
+    public static String VIRTUAL_SCAN_NUM_TABLES = "vsnt";
+    public static String VIRTUAL_SCAN_CURRENT_INDEX_RANGE = "vscir";
     public static String VIRTUAL_SCAN_PRIM_KEY = "vspk";
     public static String VIRTUAL_SCAN_SEC_KEY = "vssk";
     public static String VIRTUAL_SCAN_MOVE_AFTER = "vsma";
@@ -276,6 +278,8 @@ public class NsonProtocol {
         {VIRTUAL_SCANS,"VIRTUAL_SCANS"},
         {VIRTUAL_SCAN_SID,"VIRTUAL_SCAN_SID"},
         {VIRTUAL_SCAN_PID,"VIRTUAL_SCAN_PID"},
+        {VIRTUAL_SCAN_NUM_TABLES,"VIRTUAL_SCAN_NUM_TABLES"},
+        {VIRTUAL_SCAN_CURRENT_INDEX_RANGE,"VIRTUAL_SCAN_CURRENT_INDEX_RANGE"},
         {VIRTUAL_SCAN_PRIM_KEY,"VIRTUAL_SCAN_PRIM_KEY"},
         {VIRTUAL_SCAN_SEC_KEY,"VIRTUAL_SCAN_SEC_KEY"},
         {VIRTUAL_SCAN_MOVE_AFTER,"VIRTUAL_SCAN_MOVE_AFTER"},

--- a/driver/src/main/java/oracle/nosql/driver/query/VirtualScan.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/VirtualScan.java
@@ -10,43 +10,110 @@ package oracle.nosql.driver.query;
 
 public class VirtualScan {
 
+    public static class TableResumeInfo {
+
+        final private int theCurrentIndexRange;
+        final private byte[] thePrimResumeKey;        
+        final private byte[] theSecResumeKey;
+        final private boolean theMoveAfterResumeKey;
+
+        final private byte[] theDescResumeKey;
+        final private int[] theJoinPathTables;
+        final private byte[] theJoinPathKey;
+        final private byte[] theJoinPathSecKey;
+        final private boolean theJoinPathMatched;
+
+        public TableResumeInfo(
+            int currentIndexRange,
+            byte[] primKey,
+            byte[] secKey,
+            boolean moveAfterResumeKey,
+            byte[] descResumeKey,
+            int[] joinPathTables,
+            byte[] joinPathKey,
+            byte[] joinPathSecKey,
+            boolean joinPathMatched) {
+
+            theCurrentIndexRange = currentIndexRange;
+            thePrimResumeKey = primKey;
+            theSecResumeKey = secKey;
+            theMoveAfterResumeKey = moveAfterResumeKey;
+            theDescResumeKey = descResumeKey;
+            theJoinPathTables = joinPathTables;
+            theJoinPathKey = joinPathKey;
+            theJoinPathSecKey = joinPathSecKey;
+            theJoinPathMatched = joinPathMatched;
+        }
+
+        @Override
+        public String toString() {
+
+            StringBuilder sb = new StringBuilder();
+
+            sb.append("theCurrentIndexRange = ").append(theCurrentIndexRange);
+            sb.append("\n");
+
+            if (thePrimResumeKey != null) {
+                sb.append("thePrimResumeKey = ");
+                sb.append(PlanIter.printByteArray(thePrimResumeKey));
+                sb.append("\n");
+            }
+
+            if (theSecResumeKey != null) {
+                sb.append("theSecResumeKey = ");
+                sb.append(PlanIter.printByteArray(theSecResumeKey));
+                sb.append("\n");
+            }
+
+            sb.append("theMoveAfterResumeKey = ").append(theMoveAfterResumeKey);
+            sb.append("\n");
+
+            if (theDescResumeKey != null) {
+                sb.append("theDescResumeKey = ");
+                sb.append(PlanIter.printByteArray(theDescResumeKey));
+                sb.append("\n");
+            }
+
+            if (theJoinPathTables != null) {
+                sb.append("theJoinPathTables = ");
+                sb.append(PlanIter.printIntArray(theJoinPathTables));
+                sb.append("\n");
+            }
+
+            if (theJoinPathKey != null) {
+                sb.append("theJoinPathKey = ");
+                sb.append(PlanIter.printByteArray(theJoinPathKey));
+                sb.append("\n");
+            }
+
+            if (theJoinPathSecKey != null) {
+                sb.append("theJoinPathSecKey = ");
+                sb.append(PlanIter.printByteArray(theJoinPathSecKey));
+                sb.append("\n");
+            }
+
+            sb.append("theJoinPathMatched = ").append(theJoinPathMatched);
+            sb.append("\n");
+
+            return sb.toString();
+        }
+    }
+
     final private int theSID;
-
     final private int thePID;
+    final private TableResumeInfo[] theTableRIs;
 
-    final private byte[] thePrimResumeKey;        
-    final private byte[] theSecResumeKey;
-    final private boolean theMoveAfterResumeKey;
-
-    final private byte[] theDescResumeKey;
-    final private int[] theJoinPathTables;
-    final private byte[] theJoinPathKey;
-    final private byte[] theJoinPathSecKey;
-    final private boolean theJoinPathMatched;
 
     boolean theFirstBatch = true;
 
     public VirtualScan(
         int pid,
         int sid,
-        byte[] primKey,
-        byte[] secKey,
-        boolean moveAfterResumeKey,
-        byte[] descResumeKey,
-        int[] joinPathTables,
-        byte[] joinPathKey,
-        byte[] joinPathSecKey,
-        boolean joinPathMatched) {
+        TableResumeInfo[] tableRIs) {
+
         theSID = sid;
         thePID = pid;
-        thePrimResumeKey = primKey;
-        theSecResumeKey = secKey;
-        theMoveAfterResumeKey = moveAfterResumeKey;
-        theDescResumeKey = descResumeKey;
-        theJoinPathTables = joinPathTables;
-        theJoinPathKey = joinPathKey;
-        theJoinPathSecKey = joinPathSecKey;
-        theJoinPathMatched = joinPathMatched;
+        theTableRIs = tableRIs;
     }
 
     public int sid() {
@@ -57,36 +124,44 @@ public class VirtualScan {
         return thePID;
     }
 
-    public byte[] secKey() {
-        return theSecResumeKey;
+    public int numTables() {
+        return theTableRIs.length;
     }
 
-    public byte[] primKey() {
-        return thePrimResumeKey;
+    public int currentIndexRange(int i) {
+        return theTableRIs[i].theCurrentIndexRange;
     }
 
-    public boolean moveAfterResumeKey() {
-        return theMoveAfterResumeKey;
+    public byte[] secKey(int i) {
+        return theTableRIs[i].theSecResumeKey;
     }
 
-    public byte[] descResumeKey() {
-        return theDescResumeKey;
+    public byte[] primKey(int i) {
+        return theTableRIs[i].thePrimResumeKey;
+    }
+    
+    public boolean moveAfterResumeKey(int i) {
+        return theTableRIs[i].theMoveAfterResumeKey;
     }
 
-    public int[] joinPathTables() {
-        return theJoinPathTables;
+    public byte[] descResumeKey(int i) {
+        return theTableRIs[i].theDescResumeKey;
     }
 
-    public byte[] joinPathKey() {
-        return theJoinPathKey;
+    public int[] joinPathTables(int i) {
+        return theTableRIs[i].theJoinPathTables;
     }
 
-    public byte[] joinPathSecKey() {
-        return theJoinPathSecKey;
+    public byte[] joinPathKey(int i) {
+        return theTableRIs[i].theJoinPathKey;
     }
 
-    public boolean joinPathMatched() {
-        return theJoinPathMatched;
+    public byte[] joinPathSecKey(int i) {
+        return theTableRIs[i].theJoinPathSecKey;
+    }
+
+    public boolean joinPathMatched(int i) {
+        return theTableRIs[i].theJoinPathMatched;
     }
 
     public boolean isFirstBatch() {
@@ -103,6 +178,12 @@ public class VirtualScan {
 
         sb.append("theFirstBatch = ").append(theFirstBatch);
         sb.append("\n");
+
+        for (int i = 0; i < theTableRIs.length; ++i) {
+            sb.append("Table RI ").append(i).append(":\n");
+            sb.append(theTableRIs[i]);
+        }
+
         return sb.toString();
     }
 }


### PR DESCRIPTION
In the context of the inner joins work I simplified the VirtualScan info shipped between the proxy and the sdks: instead of sending the full KV VirtualScan, only the sid and pid were sent. The rational was that the full VirtualScan info is also contained in the continuation key and, at the proxy, it can be obtained from the continuation key. However, this does not work for sorting queries, because in this case, there is a separate continuation key for each shard. When a new virtual scan is created for a shard, the sdk must send a null continuation key to the proxy for the 1st batch of this scan. So, in this case, the proxy must receive the full VirtualScan separately.

