### PR TITLE
Preparing for 5.4.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased]
+## [5.4.17] 2025-03-03
+
+### Added
 - PrepareQueryException. This exception is thrown if a prepared query is
   executed after (a) the index used by the query has been dropped and then
   re-created with a different schema, or (b) one or more of the referenced
   tables has been altered (via the alter table statement). It is only used
   with server 25.1 or higher that supports it.
+
+### Changed
+- Update netty dependency to 4.1.118.Final
 
 ## [5.4.16] 2024-11-21
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ project. The version changes with each release.
 <dependency>
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.4.15</version>
+  <version>5.4.17</version>
 </dependency>
 ```
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.4.17-SNAPSHOT</version>
+  <version>5.4.17</version>
   <packaging>jar</packaging>
 
   <organization>

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -12,5 +12,5 @@ public class SDKVersion {
     /**
      * The full X.Y.Z version of the current SDK
      */
-    public static final String VERSION = "5.4.16";
+    public static final String VERSION = "5.4.17";
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.oracle.nosql.sdk</groupId>
-  <version>5.4.17-SNAPSHOT</version>
+  <version>5.4.17</version>
   <artifactId>nosql-java-sdk-examples</artifactId>
   <name>Oracle NoSQL Database Java Examples</name>
   <description>Java examples for Oracle NoSQL Database</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosql-java-sdk</artifactId>
-  <version>5.4.17-SNAPSHOT</version>
+  <version>5.4.17</version>
   <packaging>pom</packaging>
   <name>Oracle NoSQL SDK</name>
   <description>


### PR DESCRIPTION
### Added
- PrepareQueryException. This exception is thrown if a prepared query is
  executed after (a) the index used by the query has been dropped and then
  re-created with a different schema, or (b) one or more of the referenced
  tables has been altered (via the alter table statement). It is only used
  with server 25.1 or higher that supports it.

### Changed
- Update netty dependency to 4.1.118.Final
