### PR TITLE
Add parallel query function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Parallel Query feature to enable multiple coordinated threads, processes, or
+  machines to operate on distinct subsets of rows. The use of the features
+  requires a server version that supports it. An unsupported server returns 0
+  for the maxium parallelism. The following API is added
+  - PreparedStatement.getMaximumParallelism()
+  - QueryRequest.get/setNumberOfOperations()
+  - QueryRequest.get/setOperationNumber()
+
 ## [5.4.17] 2025-03-03
 
 ### Added

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.4.17</version>
+  <version>5.4.parallel</version>
   <packaging>jar</packaging>
 
   <organization>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.4.parallel</version>
+  <version>5.1.18-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <organization>

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -12,5 +12,5 @@ public class SDKVersion {
     /**
      * The full X.Y.Z version of the current SDK
      */
-    public static final String VERSION = "5.4.parallel";
+    public static final String VERSION = "5.1.18-SNAPSHOT";
 }

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -12,5 +12,5 @@ public class SDKVersion {
     /**
      * The full X.Y.Z version of the current SDK
      */
-    public static final String VERSION = "5.4.17";
+    public static final String VERSION = "5.4.parallel";
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -980,6 +980,7 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
     /**
      * Returns the individual operation number for this query if it is
      * participating in a coordinated parallel query operation or 0 if not.
+     * The value is 1-based.
      * @return the operation number
      * @since 5.4.18
      */
@@ -1007,7 +1008,8 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
      * Sets the individual operation number for this query if it is
      * participating in a coordinated parallel query operation. This number
      * must be less than or equal to the total number of operations.
-     * This value will only be valid if the request contains a prepared query.
+     * The operation number is 1-based and the value will only be valid if
+     * the request contains a prepared query.
      * Validation is performed during query execution.
      *
      * @param operationNumber the operation number

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/PrepareRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/PrepareRequestSerializer.java
@@ -167,7 +167,8 @@ public class PrepareRequestSerializer extends BinaryProtocol
                                   externalVars,
                                   namespace,
                                   tableName,
-                                  operation);
+                                  operation,
+                                  0); /* no parallelism available */
 
         result.setPreparedStatement(prep);
         result.setTopology(ti);

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
@@ -55,6 +55,7 @@ public class NsonProtocol {
     public static String LIST_MAX_TO_READ = "lx";
     public static String LIST_START_INDEX = "ls";
     public static String MATCH_VERSION = "mv";
+    public static String MAX_QUERY_PARALLELISM = "mp";
     public static String MAX_READ_KB = "mr";
     public static String MAX_SHARD_USAGE_PERCENT = "ms";
     public static String MAX_WRITE_KB = "mw";
@@ -62,6 +63,7 @@ public class NsonProtocol {
     public static String NAMESPACE = "ns";
     public static String NUMBER_LIMIT = "nl";
     public static String NUM_OPERATIONS = "no";
+    public static String NUM_QUERY_OPERATIONS = "nq";
     public static String OPERATION = "op";
     public static String OPERATIONS = "os";
     public static String OPERATION_ID = "od";
@@ -74,6 +76,7 @@ public class NsonProtocol {
     public static String PREPARED_STATEMENT = "ps";
     public static String QUERY = "q";
     public static String QUERY_NAME = "qn";
+    public static String QUERY_OPERATION_NUM = "on";
     public static String QUERY_VERSION = "qv";
     public static String RANGE = "rg";
     public static String RANGE_PATH = "rp";
@@ -225,6 +228,7 @@ public class NsonProtocol {
         {LIST_MAX_TO_READ,"LIST_MAX_TO_READ"},
         {LIST_START_INDEX,"LIST_START_INDEX"},
         {MATCH_VERSION,"MATCH_VERSION"},
+        {MAX_QUERY_PARALLELISM,"MAX_QUERY_PARALLELISM"},
         {MAX_READ_KB,"MAX_READ_KB"},
         {MAX_SHARD_USAGE_PERCENT,"MAX_SHARD_USAGE_PERCENT"},
         {MAX_WRITE_KB,"MAX_WRITE_KB"},
@@ -232,6 +236,7 @@ public class NsonProtocol {
         {NAMESPACE,"NAMESPACE"},
         {NUMBER_LIMIT,"NUMBER_LIMIT"},
         {NUM_OPERATIONS,"NUM_OPERATIONS"},
+        {NUM_QUERY_OPERATIONS,"NUM_QUERY_OPERATIONS"},
         {OPERATION,"OPERATION"},
         {OPERATIONS,"OPERATIONS"},
         {OPERATION_ID,"OPERATION_ID"},
@@ -244,6 +249,7 @@ public class NsonProtocol {
         {PREPARED_STATEMENT,"PREPARED_STATEMENT"},
         {QUERY,"QUERY"},
         {QUERY_NAME,"QUERY_NAME"},
+        {QUERY_OPERATION_NUM,"QUERY_OPERATION_NUM"},
         {QUERY_VERSION,"QUERY_VERSION"},
         {RANGE,"RANGE"},
         {RANGE_PATH,"RANGE_PATH"},

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
@@ -1011,7 +1011,7 @@ public class NsonSerializerFactory implements SerializerFactory {
             byte[] contKey = null;
             VirtualScan[] virtualScans = null;
             TreeMap<String, String> queryTraces = null;
-            int maxParallelism = 1; /* default value */
+            int maxParallelism = 0; /* default value */
 
             MapWalker walker = getMapWalker(in);
             while (walker.hasNext()) {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.oracle.nosql.sdk</groupId>
-  <version>5.4.17</version>
+  <version>5.4.parallel</version>
   <artifactId>nosql-java-sdk-examples</artifactId>
   <name>Oracle NoSQL Database Java Examples</name>
   <description>Java examples for Oracle NoSQL Database</description>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.oracle.nosql.sdk</groupId>
       <artifactId>nosqldriver</artifactId>
-      <version>5.4.17</version>
+      <version>5.4.parallel</version>
     </dependency>
   </dependencies>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.oracle.nosql.sdk</groupId>
-  <version>5.4.parallel</version>
+  <version>5.1.18-SNAPSHOT</version>
   <artifactId>nosql-java-sdk-examples</artifactId>
   <name>Oracle NoSQL Database Java Examples</name>
   <description>Java examples for Oracle NoSQL Database</description>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.oracle.nosql.sdk</groupId>
       <artifactId>nosqldriver</artifactId>
-      <version>5.4.parallel</version>
+      <version>5.1.18-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosql-java-sdk</artifactId>
-  <version>5.4.17</version>
+  <version>5.4.parallel</version>
   <packaging>pom</packaging>
   <name>Oracle NoSQL SDK</name>
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosql-java-sdk</artifactId>
-  <version>5.4.parallel</version>
+  <version>5.1.18-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Oracle NoSQL SDK</name>
   <description>


### PR DESCRIPTION
Add the ability to perform queries in parallel where coordinated threads or processes can each operate on a subset of a table's rows. This feature requires server support