### PR TITLE
Add rowMetadat to multi delete request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   - QueryRequest.get/setNumberOfOperations()
   - QueryRequest.get/setOperationNumber()
 - Added new cloud region codes: hsg, abl, dfw, pbv, nbq, ibg, pcz, mez, den, kal
-- Added rowMetadata support, new API for Get/Put/Delete request and result
+- Added rowMetadata support, new API for Get/Put/Delete/MultiDelete request and result
   get/set RomMetadata.
 - Added row creation time support, new API: GetResult getCreationTime(), 
   Put/Delete/Write/WriteMultiple Result getExistingCreationTime().

--- a/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DeleteRequest.java
@@ -260,14 +260,20 @@ public class DeleteRequest extends WriteRequest {
     }
 
     /**
-     * Sets the row metadata to use for this request.
-     * This is an optional parameter.
-     * The @parameter rowMetadata must be in a JSON Object format or null,
-     * otherwise an IllegalArgumentException is thrown.
+     * Sets the row metadata to use for this request. This is an optional
+     * parameter.<p>
+     *
+     * Row metadata is associated to a certain version of a row. Any subsequent
+     * write operation will use its own row metadata value. If not specified
+     * null will be used by default.<p>
+     *
+     * The @parameter rowMetadata must be null or a valid JSON construct:
+     * object, array, string, number, true, false or null, otherwise an
+     * IllegalArgumentException is thrown.
      *
      * @param rowMetadata the row metadata
      * @throws IllegalArgumentException if rowMetadata not null and invalid
-     * JSON Object format
+     * JSON construct
      *
      * @since 5.4.18
      * @return this

--- a/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
@@ -27,7 +27,7 @@ public abstract class DurableRequest extends Request {
      * Returns the durability setting for this operation.
      * On-prem only.
      *
-     * @return durability, if set. Otherwise null.
+     * @return durability, if set, otherwise null.
      */
     public Durability getDurability() {
         return durability;

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -259,7 +259,7 @@ public class MultiDeleteRequest extends DurableRequest {
             return this;
         }
 
-        JsonUtils.validateJson(rowMetadata);
+        JsonUtils.validateJsonConstruct(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -13,6 +13,7 @@ import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.iam.SignatureProvider;
 import oracle.nosql.driver.ops.serde.Serializer;
 import oracle.nosql.driver.ops.serde.SerializerFactory;
+import oracle.nosql.driver.values.JsonUtils;
 import oracle.nosql.driver.values.MapValue;
 
 /**
@@ -22,7 +23,7 @@ import oracle.nosql.driver.values.MapValue;
  * <p>
  * A range is specified using a partial key plus a range based on the
  * portion of the key that is not provided. For example if a table's primary key
- * is &lt;id, timestamp&gt; and the its shard key is the id, it is possible
+ * is &lt;id, timestamp&gt; and its shard key is the id, it is possible
  * to delete a range of timestamp values for a specific id by providing an id
  * but no timestamp in the value used for {@link #setKey} and providing a range
  * of timestamp values in the {@link FieldRange} used in {@link #setRange}.
@@ -41,6 +42,7 @@ public class MultiDeleteRequest extends DurableRequest {
     private byte[] continuationKey;
     private FieldRange range;
     private int maxWriteKB;
+    private String rowMetadata;
 
     /**
      * Cloud service only.
@@ -230,6 +232,39 @@ public class MultiDeleteRequest extends DurableRequest {
     public MultiDeleteRequest setNamespace(String namespace) {
         super.setNamespaceInternal(namespace);
         return this;
+    }
+
+    /**
+     * Sets the row metadata to use for the operation.
+     * The @parameter rowMetadata must be in a JSON Object format or null,
+     * otherwise an IllegalArgumentException is thrown.
+     *
+     * @param rowMetadata the row metadata
+     * @throws IllegalArgumentException if rowMetadata not null and invalid
+     * JSON Object format
+     *
+     * @return this
+     * @since 5.4.18
+     */
+    public MultiDeleteRequest setRowMetadata(String rowMetadata) {
+        if (rowMetadata == null) {
+            this.rowMetadata = null;
+            return this;
+        }
+
+        JsonUtils.validateJsonObject(rowMetadata);
+        this.rowMetadata = rowMetadata;
+        return this;
+    }
+
+    /**
+     * Returns the row metadata set for this request, or null if not set.
+     *
+     * @return the row metadata
+     * @since 5.4.18
+     */
+    public String getRowMetadata() {
+        return rowMetadata;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/MultiDeleteRequest.java
@@ -235,13 +235,20 @@ public class MultiDeleteRequest extends DurableRequest {
     }
 
     /**
-     * Sets the row metadata to use for the operation.
-     * The @parameter rowMetadata must be in a JSON Object format or null,
-     * otherwise an IllegalArgumentException is thrown.
+     * Sets the row metadata to use for the operation. This is an optional
+     * parameter.<p>
+     *
+     * Row metadata is associated to a certain version of a row. Any subsequent
+     * write operation will use its own row metadata value. If not specified
+     * null will be used by default.<p>
+     *
+     * The @parameter rowMetadata must be null or a valid JSON construct:
+     * object, array, string, number, true, false or null, otherwise an
+     * IllegalArgumentException is thrown.
      *
      * @param rowMetadata the row metadata
      * @throws IllegalArgumentException if rowMetadata not null and invalid
-     * JSON Object format
+     * JSON construct
      *
      * @return this
      * @since 5.4.18
@@ -252,7 +259,7 @@ public class MultiDeleteRequest extends DurableRequest {
             return this;
         }
 
-        JsonUtils.validateJsonObject(rowMetadata);
+        JsonUtils.validateJson(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PutRequest.java
@@ -439,13 +439,19 @@ public class PutRequest extends WriteRequest {
 
     /**
      * Sets the row metadata to use for this request.
-     * This is an optional parameter.
-     * The @parameter rowMetadata must be in a JSON Object format or null,
-     * otherwise an IllegalArgumentException is thrown.
+     * This is an optional parameter.<p>
+     *
+     * Row metadata is associated to a certain version of a row. Any subsequent
+     * write operation will use its own row metadata value. If not specified
+     * null will be used by default.<p>
+     *
+     * The @parameter rowMetadata must be null or a valid JSON construct:
+     * object, array, string, number, true, false or null, otherwise an
+     * IllegalArgumentException is thrown.
      *
      * @param rowMetadata the row metadata
      * @throws IllegalArgumentException if rowMetadata not null and invalid
-     * JSON Object format
+     * JSON construct
      *
      * @since 5.4.18
      * @return this

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -925,15 +925,22 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
     }
 
     /**
-     * Sets the row metadata to use for the operation. This setting only applies
-     * if the query modifies any rows using an INSERT, UPDATE or UPSERT statement.
-     * If the query is read-only this option is ignored.
-     * The @parameter rowMetadata must be in a JSON Object format or null,
-     * otherwise an IllegalArgumentException is thrown.
+     * Sets the row metadata to use for the operation. This setting is optional
+     * and only applies if the query modifies or deletes any rows using an
+     * INSERT, UPDATE, UPSERT or DELETE statement. If the query is read-only
+     * this setting is ignored.<p>
+     *
+     * Row metadata is associated to a certain version of a row. Any subsequent
+     * write operation will use its own row metadata value. If not specified
+     * null will be used by default.<p>
+     *
+     * The @parameter rowMetadata must be null or a valid JSON construct:
+     * object, array, string, number, true, false or null, otherwise an
+     * IllegalArgumentException is thrown.
      *
      * @param rowMetadata the row metadata
      * @throws IllegalArgumentException if rowMetadata not null and invalid
-     * JSON Object format
+     * JSON construct
      *
      * @return this
      * @since 5.4.18
@@ -944,7 +951,7 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
             return this;
         }
 
-        JsonUtils.validateJsonObject(rowMetadata);
+        JsonUtils.validateJson(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -950,9 +950,9 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
     }
 
     /**
-     * Returns the consistency set for this request, or null if not set.
+     * Returns the row metadata set for this request, or null if not set.
      *
-     * @return the consistency
+     * @return the row metadata
      * @since 5.4.18
      */
     public String getRowMetadata() {

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -951,7 +951,7 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
             return this;
         }
 
-        JsonUtils.validateJson(rowMetadata);
+        JsonUtils.validateJsonConstruct(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
@@ -90,7 +90,7 @@ public abstract class WriteRequest extends DurableRequest {
             return this;
         }
 
-        JsonUtils.validateJson(rowMetadata);
+        JsonUtils.validateJsonConstruct(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/WriteRequest.java
@@ -67,8 +67,14 @@ public abstract class WriteRequest extends DurableRequest {
 
     /**
      * Sets the row metadata to use for this request.
-     * This is an optional parameter.
-     * The @parameter rowMetadata must be in a JSON Object format or null,
+     * This is an optional parameter.<p>
+     *
+     * Row metadata is associated to a certain version of a row. Any subsequent
+     * write operation will use its own row metadata value. If not specified
+     * null will be used by default.<p>
+     *
+     * The @parameter rowMetadata must be null or in a valid JSON construct:
+     * object, array, string, number, true, false or null,
      * otherwise an IllegalArgumentException is thrown.
      *
      * @param rowMetadata the row metadata
@@ -84,7 +90,7 @@ public abstract class WriteRequest extends DurableRequest {
             return this;
         }
 
-        JsonUtils.validateJsonObject(rowMetadata);
+        JsonUtils.validateJson(rowMetadata);
         this.rowMetadata = rowMetadata;
         return this;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
@@ -646,6 +646,7 @@ public class NsonSerializerFactory implements SerializerFactory {
             writeContinuationKey(ns, rq.getContinuationKey());
             writeFieldRange(ns, rq.getRange());
             writeKey(ns, rq);
+            writeMapField(ns, ROW_METADATA, rq.getRowMetadata());
             endMap(ns, PAYLOAD);
             ns.endMap(0); // top level object
         }

--- a/driver/src/main/java/oracle/nosql/driver/values/JsonUtils.java
+++ b/driver/src/main/java/oracle/nosql/driver/values/JsonUtils.java
@@ -794,4 +794,40 @@ public class JsonUtils {
             throw new IllegalArgumentException("JSON parse failed: " + jpe);
         }
     }
+
+    /**
+     * Validates input is a valid JSON: object, array, string, number, true,
+     * false or null. Throws IllegalArgumentException if not valid.
+     * Multiple JSON Objects are not allowed. Strings must use only double
+     * quotes (").
+     */
+    public static void validateJson(String jsonInput) {
+        try (JsonParser jp = createParserWithOptions(jsonInput, null)) {
+            JsonToken token = jp.nextToken();
+            if (token == null /*|| !JsonToken.START_OBJECT.equals(token)*/) {
+                throw new IllegalArgumentException("Value is not a valid JSON construct.");
+            }
+            int s = 1;
+            while (!jp.isClosed()) {
+                token = jp.nextToken();
+                if (token != null && JsonToken.START_OBJECT.equals(token)) {
+                    if (s == 0) {
+                        throw new IllegalArgumentException("Multiple JSON " +
+                            "Objects not allowed.");
+                    }
+                    s++;
+                }
+                if (token != null && JsonToken.END_OBJECT.equals(token)) {
+                    s--;
+                }
+            }
+//            if (token != null && !JsonToken.END_OBJECT.equals(token)) {
+//                throw new IllegalArgumentException("Not a JSON Object end");
+//            }
+        } catch (IOException ioe) {
+            throw new IllegalArgumentException("JSON parse failed: " + ioe);
+        } catch (JsonParseException jpe) {
+            throw new IllegalArgumentException("JSON parse failed: " + jpe);
+        }
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/values/JsonUtils.java
+++ b/driver/src/main/java/oracle/nosql/driver/values/JsonUtils.java
@@ -760,51 +760,15 @@ public class JsonUtils {
     }
 
     /**
-     * Validates input is a valid jsonObject. Throws IllegalArgumentException if
-     * not. Number, string, null, boolean or array alone are not allowed.
+     * Validates input is a valid JSON construct: object, array, string, number,
+     * true, false or null. Throws IllegalArgumentException if not valid.
      * Multiple JSON Objects are not allowed. Strings must use only double
      * quotes (").
      */
-    public static void validateJsonObject(String jsonInput) {
+    public static void validateJsonConstruct(String jsonInput) {
         try (JsonParser jp = createParserWithOptions(jsonInput, null)) {
             JsonToken token = jp.nextToken();
-            if (token == null || !JsonToken.START_OBJECT.equals(token)) {
-                throw new IllegalArgumentException("Not a JSON Object");
-            }
-            int s = 1;
-            while (!jp.isClosed()) {
-                token = jp.nextToken();
-                if (token != null && JsonToken.START_OBJECT.equals(token)) {
-                    if (s == 0) {
-                        throw new IllegalArgumentException("Multiple JSON " +
-                            "Objects not allowed");
-                    }
-                    s++;
-                }
-                if (token != null && JsonToken.END_OBJECT.equals(token)) {
-                    s--;
-                }
-            }
-            if (token != null && !JsonToken.END_OBJECT.equals(token)) {
-                throw new IllegalArgumentException("Not a JSON Object end");
-            }
-        } catch (IOException ioe) {
-            throw new IllegalArgumentException("JSON parse failed: " + ioe);
-        } catch (JsonParseException jpe) {
-            throw new IllegalArgumentException("JSON parse failed: " + jpe);
-        }
-    }
-
-    /**
-     * Validates input is a valid JSON: object, array, string, number, true,
-     * false or null. Throws IllegalArgumentException if not valid.
-     * Multiple JSON Objects are not allowed. Strings must use only double
-     * quotes (").
-     */
-    public static void validateJson(String jsonInput) {
-        try (JsonParser jp = createParserWithOptions(jsonInput, null)) {
-            JsonToken token = jp.nextToken();
-            if (token == null /*|| !JsonToken.START_OBJECT.equals(token)*/) {
+            if (token == null) {
                 throw new IllegalArgumentException("Value is not a valid JSON construct.");
             }
             int s = 1;
@@ -821,9 +785,6 @@ public class JsonUtils {
                     s--;
                 }
             }
-//            if (token != null && !JsonToken.END_OBJECT.equals(token)) {
-//                throw new IllegalArgumentException("Not a JSON Object end");
-//            }
         } catch (IOException ioe) {
             throw new IllegalArgumentException("JSON parse failed: " + ioe);
         } catch (JsonParseException jpe) {


### PR DESCRIPTION
Fix rowMetadata on a multiDelete operation.
Allow JSON constructs rather than only JSON Object.