### PR TITLE
Restore legacy GroupIter.theIsRegrouping for pre-V6 query plans

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/query/GroupIter.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/GroupIter.java
@@ -401,7 +401,11 @@ public class GroupIter extends PlanIter {
         if (queryVersion >= QueryDriver.QUERY_V6) {
             theIsRegrouping = in.readBoolean();
         } else {
-            theIsRegrouping = false;
+            /*
+             * Pre-QUERY_V6 plans did not serialize this flag. Preserve the old
+             * behavior of flattening partial array_collect() results.
+             */
+            theIsRegrouping = true;
         }
     }
 


### PR DESCRIPTION
Pre-QUERY_V6 GroupIter plans do not serialize the regrouping flag, and defaulting the missing flag to false changed the legacy driver behavior.

Non-distinct array_collect() results that require driver-side regrouping could return nested partial arrays instead of one flattened array. For example, the result should be [345,345,349] instead of [[345,345],[349]].

This fix defaults the missing pre-V6 regrouping flag to true to preserve the legacy behavior, while keeping V6 and newer plans controlled by the serialized flag.

This bug was found by QTF test in the httpproxy onprem-26.1 branch.