### PR TITLE
Adding ML-KEM support via netty-tcnative-boringssl-static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+
+### Changed
+- Changed SSL/TLS to use netty-tcnative-boringssl-static to enable
+  more secure cyphers/protocols including ML-KEM
+
+
 ## [5.4.23] 2026-06-26
 
 ### Fixed

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -47,6 +47,7 @@
     <java.apidoc>https://docs.oracle.com/en/java/javase/11/docs/api/</java.apidoc>
     <maven.deploy.skip>false</maven.deploy.skip>
     <netty.version>4.1.132.Final</netty.version>
+    <netty.tcnative.version>2.0.74.Final</netty.tcnative.version>
     <jackson.version>2.18.6</jackson.version>
    <!-- by default, skip tests; tests require a profile -->
    <maven.test.skip>true</maven.test.skip>
@@ -246,6 +247,11 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
       <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${netty.tcnative.version}</version>
     </dependency>
 
     <!-- test -->

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosqldriver</artifactId>
-  <version>5.4.23</version>
+  <version>5.4.24-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <organization>

--- a/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
+++ b/driver/src/main/java/oracle/nosql/driver/SDKVersion.java
@@ -12,5 +12,5 @@ public class SDKVersion {
     /**
      * The full X.Y.Z version of the current SDK
      */
-    public static final String VERSION = "5.4.23";
+    public static final String VERSION = "5.4.24-SNAPSHOT";
 }

--- a/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/NoSQLHandleImpl.java
@@ -50,6 +50,7 @@ import oracle.nosql.driver.ops.TableUsageRequest;
 import oracle.nosql.driver.ops.TableUsageResult;
 import oracle.nosql.driver.ops.WriteMultipleRequest;
 import oracle.nosql.driver.ops.WriteMultipleResult;
+import oracle.nosql.driver.util.NettySslContextUtil;
 import oracle.nosql.driver.values.FieldValue;
 import oracle.nosql.driver.values.JsonUtils;
 import oracle.nosql.driver.values.MapValue;
@@ -125,7 +126,8 @@ public class NoSQLHandleImpl implements NoSQLHandle {
         }
         if (config.getServiceURL().getProtocol().equalsIgnoreCase("HTTPS")) {
             try {
-                SslContextBuilder builder = SslContextBuilder.forClient();
+                SslContextBuilder builder =
+                    NettySslContextUtil.newClientContextBuilder();
                 if (config.getSSLCipherSuites() != null) {
                     builder.ciphers(config.getSSLCipherSuites());
                 }

--- a/driver/src/main/java/oracle/nosql/driver/iam/AbstractTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/AbstractTokenSupplier.java
@@ -22,10 +22,10 @@ import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.httpclient.HttpClient;
 import oracle.nosql.driver.util.HttpRequestUtil;
+import oracle.nosql.driver.util.NettySslContextUtil;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 
 abstract class AbstractTokenSupplier
         implements TokenSupplier{
@@ -143,7 +143,7 @@ abstract class AbstractTokenSupplier
 
         SslContext sslCtx;
         try {
-            sslCtx = SslContextBuilder.forClient().build();
+            sslCtx = NettySslContextUtil.newClientContextBuilder().build();
         } catch (SSLException se) {
             throw new IllegalStateException(
                     "Unable to build SSL context for http client", se);

--- a/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
@@ -36,6 +36,7 @@ import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.httpclient.HttpClient;
 import oracle.nosql.driver.iam.SessionKeyPairSupplier.DefaultSessionKeySupplier;
 import oracle.nosql.driver.util.HttpRequestUtil;
+import oracle.nosql.driver.util.NettySslContextUtil;
 import oracle.nosql.driver.values.FieldValue;
 import oracle.nosql.driver.values.MapValue;
 
@@ -43,7 +44,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 
 /**
  * @hidden
@@ -171,7 +171,7 @@ class OkeWorkloadIdentityProvider
          */
         final SslContext sslCtx;
         try {
-            sslCtx = SslContextBuilder.forClient()
+            sslCtx = NettySslContextUtil.newClientContextBuilder()
                 .trustManager(kubernetesCaCertFile)
                 .build();
         } catch (SSLException se) {

--- a/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
@@ -26,9 +26,9 @@ import javax.security.auth.Refreshable;
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.SecurityInfoNotReadyException;
 import oracle.nosql.driver.httpclient.HttpClient;
+import oracle.nosql.driver.util.NettySslContextUtil;
 
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 
 /**
  * @hidden
@@ -130,7 +130,7 @@ class SecurityTokenSupplier implements TokenSupplier {
 
         if (sslCtx == null) {
             try {
-                sslCtx = SslContextBuilder.forClient().build();
+                sslCtx = NettySslContextUtil.newClientContextBuilder().build();
             } catch (SSLException se) {
                 throw new IllegalStateException(
                     "Unable to build SSL context for http client", se);

--- a/driver/src/main/java/oracle/nosql/driver/util/NettySslContextUtil.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/NettySslContextUtil.java
@@ -1,0 +1,34 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.util;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+
+/**
+ * Utility methods for creating Netty SSL contexts.
+ */
+public final class NettySslContextUtil {
+
+    private NettySslContextUtil() {
+    }
+
+    /**
+     * Creates a client SSL context builder that prefers the Netty OpenSSL
+     * provider when tcnative is available, falling back to the JDK provider
+     * otherwise.
+     */
+    public static SslContextBuilder newClientContextBuilder() {
+        SslContextBuilder builder = SslContextBuilder.forClient();
+        if (OpenSsl.isAvailable()) {
+            builder.sslProvider(SslProvider.OPENSSL);
+        }
+        return builder;
+    }
+}

--- a/driver/src/test/java/oracle/nosql/driver/httpclient/ConnectionPoolTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/httpclient/ConnectionPoolTest.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 
 import oracle.nosql.driver.NoSQLHandleConfig;
+import oracle.nosql.driver.util.NettySslContextUtil;
 
 /**
  * This test is excluded from the test profiles and must be run standalone.
@@ -245,10 +245,7 @@ public class ConnectionPoolTest {
 
     private SslContext buildSslContext() {
         try {
-            SslContextBuilder builder = SslContextBuilder.forClient();
-            //builder.sessionTimeout(...);
-            //builder.sessionCacheSize(...);
-            return builder.build();
+            return NettySslContextUtil.newClientContextBuilder().build();
         } catch (SSLException e) {
             throw new IllegalStateException(
                 "Unable o create SSL context: " + e);

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.oracle.nosql.sdk</groupId>
-  <version>5.4.23</version>
+  <version>5.4.24-SNAPSHOT</version>
   <artifactId>nosql-java-sdk-examples</artifactId>
   <name>Oracle NoSQL Database Java Examples</name>
   <description>Java examples for Oracle NoSQL Database</description>
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.oracle.nosql.sdk</groupId>
       <artifactId>nosqldriver</artifactId>
-      <version>5.4.23</version>
+      <version>5.4.24-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.oracle.nosql.sdk</groupId>
   <artifactId>nosql-java-sdk</artifactId>
-  <version>5.4.23</version>
+  <version>5.4.24-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Oracle NoSQL SDK</name>
   <description>


### PR DESCRIPTION
Changed SSL/TLS to use netty-tcnative-boringssl-static to enable more secure cyphers/protocols including ML-KEM