### PR TITLE
Various medium-severity bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Changed SSL/TLS to use netty-tcnative-boringssl-static to enable
   more secure cyphers/protocols including ML-KEM
 
+### Fixed
+- Make prepared-query byte arrays immutable
+- Redact sensitive information from SystemResult.toString() and SystemRequest.toString()
+- Add/drop replica retries lack SDK idempotency token support
+- Resource-scope header values can inject outbound HTTP headers
+- Extension user-agent can inject outbound HTTP headers
+- Internal query copies drop caller-specified durability for query DML
 
 ## [5.4.23] 2026-06-26
 

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -90,7 +90,7 @@
           ConfigFileTest.java, SignatureProviderTest.java, AuthRetryTest.java,
           UserProfileProviderTest.java, InstancePrincipalsProviderTest.java,
           HandleConfigTest.java, JsonTest.java, ValueTest.java,
-          OnPremiseTest.java, ConnectionPoolTest.java
+          OnPremiseTest.java, ConnectionPoolTest.java, RequestTest.java
         </excluded.tests>
       </properties>
     </profile>
@@ -107,7 +107,8 @@
           StoreAccessTokenProviderTest.java, ResourcePrincipalProviderTest.java,
           ConfigFileTest.java, SignatureProviderTest.java, AuthRetryTest.java,
           UserProfileProviderTest.java, InstancePrincipalsProviderTest.java,
-          HandleConfigTest.java, JsonTest.java, ValueTest.java, ConnectionPoolTest.java
+          HandleConfigTest.java, JsonTest.java, ValueTest.java,
+          ConnectionPoolTest.java, RequestTest.java
         </excluded.tests>
       </properties>
     </profile>
@@ -124,7 +125,8 @@
           StoreAccessTokenProviderTest.java, ResourcePrincipalProviderTest.java,
           ConfigFileTest.java, SignatureProviderTest.java, AuthRetryTest.java,
           UserProfileProviderTest.java, InstancePrincipalsProviderTest.java,
-          HandleConfigTest.java, JsonTest.java, ValueTest.java, ConnectionPoolTest.java
+          HandleConfigTest.java, JsonTest.java, ValueTest.java,
+          ConnectionPoolTest.java, RequestTest.java
         </excluded.tests>
         <maven.buildNumber.doCheck>false</maven.buildNumber.doCheck>
       </properties>
@@ -142,7 +144,7 @@
           ConfigFileTest.java, SignatureProviderTest.java, AuthRetryTest.java,
           UserProfileProviderTest.java, InstancePrincipalsProviderTest.java,
           HandleConfigTest.java, JsonTest.java, ValueTest.java,
-          SessionTokenProviderTest.java
+          SessionTokenProviderTest.java, RequestTest.java
         </included.tests>
       </properties>
     </profile>

--- a/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
+++ b/driver/src/main/java/oracle/nosql/driver/NoSQLHandleConfig.java
@@ -8,6 +8,7 @@
 package oracle.nosql.driver;
 
 import static oracle.nosql.driver.util.CheckNull.requireNonNull;
+import static oracle.nosql.driver.util.HttpHeaderValidation.validateHttpHeaderValue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -1087,6 +1088,7 @@ public class NoSQLHandleConfig implements Cloneable {
      * @return this
      */
     public NoSQLHandleConfig setDefaultCompartment(String compartment) {
+        validateHttpHeaderValue("default compartment", compartment);
         this.compartment = compartment;
         return this;
     }
@@ -1126,6 +1128,7 @@ public class NoSQLHandleConfig implements Cloneable {
      * @since 5.4.10
      */
     public NoSQLHandleConfig setDefaultNamespace(String defaultNamespace) {
+        validateHttpHeaderValue("default namespace", defaultNamespace);
         this.defaultNamespace = defaultNamespace;
         return this;
     }
@@ -1676,6 +1679,7 @@ public class NoSQLHandleConfig implements Cloneable {
      * @since 5.3.3
      */
     public void setExtensionUserAgent(String extensionUserAgent) {
+        validateHttpHeaderValue("extension user agent", extensionUserAgent);
         if (extensionUserAgent != null && extensionUserAgent.length() > 64) {
             throw new IllegalArgumentException("Extension to the user agent " +
                 "http header too long, it can be up to 64 bytes. Length: " +

--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -973,9 +973,11 @@ public class Client {
                         name + ", message: " + ioe.getMessage());
                 /*
                  * An exception in the channel, e.g. the server may have
-                 * disconnected. Retry.
+                 * disconnected. Retry if the request allows it.
                  */
                 kvRequest.addRetryException(ioe.getClass());
+                throwIfTransportRetryNotAllowed(kvRequest, ioe,
+                                                rateDelayedMs);
                 kvRequest.incrementRetries();
                 exception = ioe;
 
@@ -1001,9 +1003,11 @@ public class Client {
                  */
                 String name = ee.getCause().getClass().getName();
                 logFine(logger, "Client ExecutionException, name: " +
-                        name + ", message: " + ee.getMessage() + ", retrying");
+                        name + ", message: " + ee.getMessage());
 
                 kvRequest.addRetryException(ee.getCause().getClass());
+                throwIfTransportRetryNotAllowed(kvRequest, ee.getCause(),
+                                                rateDelayedMs);
                 kvRequest.incrementRetries();
                 exception = ee.getCause();
                 continue;
@@ -1014,7 +1018,7 @@ public class Client {
             } catch (Throwable t) {
                 /*
                  * this is likely an exception from Netty, perhaps a bad
-                 * connection. Retry.
+                 * connection. Retry if the request allows it.
                  */
                 /* Maybe make this logFine */
                 String name = t.getClass().getName();
@@ -1022,6 +1026,7 @@ public class Client {
                         name + "message: " + t.getMessage());
 
                 kvRequest.addRetryException(t.getClass());
+                throwIfTransportRetryNotAllowed(kvRequest, t, rateDelayedMs);
                 kvRequest.incrementRetries();
                 exception = t;
                 continue;
@@ -1593,6 +1598,19 @@ public class Client {
         }
 
         return rs.getNumExceptions(InvalidAuthorizationException.class) > 0;
+    }
+
+    private void throwIfTransportRetryNotAllowed(Request request,
+                                                 Throwable cause,
+                                                 int rateDelayedMs) {
+        if (request.shouldRetry()) {
+            return;
+        }
+        request.setRateLimitDelayedMs(rateDelayedMs);
+        statsControl.observeError(request);
+        throw new NoSQLException(
+            "Request failed and is not retryable: " + cause.getMessage(),
+            cause);
     }
 
     private void handleRetry(RetryableException re,

--- a/driver/src/main/java/oracle/nosql/driver/ops/AddReplicaRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/AddReplicaRequest.java
@@ -204,4 +204,12 @@ public class AddReplicaRequest extends Request {
     public String getTypeName() {
         return "AddReplica";
     }
+
+    /**
+     * @hidden
+     */
+    @Override
+    public boolean shouldRetry() {
+        return false;
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/DropReplicaRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DropReplicaRequest.java
@@ -158,4 +158,12 @@ public class DropReplicaRequest extends Request {
     public String getTypeName() {
         return "DropReplica";
     }
+
+    /**
+     * @hidden
+     */
+    @Override
+    public boolean shouldRetry() {
+        return false;
+    }
 }

--- a/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/DurableRequest.java
@@ -37,6 +37,17 @@ public abstract class DurableRequest extends Request {
      * @hidden
      */
     @Override
+    public void copyTo(Request other) {
+        super.copyTo(other);
+        if (other instanceof DurableRequest) {
+            ((DurableRequest)other).durability = durability;
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    @Override
     public boolean doesWrites() {
         return true;
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/PreparedStatement.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PreparedStatement.java
@@ -152,7 +152,7 @@ public class PreparedStatement {
         byte operation,
         int maxParallelism) {
 
-        if (proxyStatements.isEmpty()) {
+        if (proxyStatements == null || proxyStatements.isEmpty()) {
             throw new IllegalArgumentException(
                 "Invalid prepared query: no proxy-side query");
         }
@@ -160,7 +160,7 @@ public class PreparedStatement {
         this.sqlText = sqlText;
         this.queryPlan = queryPlan;
         this.querySchema = querySchema;
-        this.proxyStatements = proxyStatements;
+        this.proxyStatements = copyProxyStatements(proxyStatements);
         this.driverQueryPlan = driverPlan;
         this.numIterators = numIterators;
         this.numRegisters = numRegisters;
@@ -327,7 +327,21 @@ public class PreparedStatement {
      * @hidden
      */
     public final byte[] getProxyStatement(int branch) {
-        return proxyStatements.get(branch);
+        return proxyStatements.get(branch).clone();
+    }
+
+    private static ArrayList<byte[]> copyProxyStatements(
+        ArrayList<byte[]> source) {
+
+        ArrayList<byte[]> copy = new ArrayList<byte[]>(source.size());
+        for (byte[] statement : source) {
+            if (statement == null) {
+                throw new IllegalArgumentException(
+                    "Invalid prepared query: null proxy-side query");
+            }
+            copy.add(statement.clone());
+        }
+        return copy;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -7,6 +7,8 @@
 
 package oracle.nosql.driver.ops;
 
+import static oracle.nosql.driver.util.HttpHeaderValidation.validateHttpHeaderValue;
+
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.RateLimiter;
 import oracle.nosql.driver.ops.serde.Serializer;
@@ -180,6 +182,7 @@ public abstract class Request {
      * @hidden
      */
     public void setCompartmentInternal(String compartment) {
+        validateHttpHeaderValue("compartment", compartment);
         this.compartment = compartment;
     }
 
@@ -224,6 +227,7 @@ public abstract class Request {
      * @hidden
      */
     protected void setNamespaceInternal(String namespace) {
+        validateHttpHeaderValue("namespace", namespace);
         this.namespace = namespace;
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/ops/SystemRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/SystemRequest.java
@@ -125,7 +125,8 @@ public class SystemRequest extends Request {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("SystemRequest: [statement=").append(new String(statement))
+        sb.append("SystemRequest: [statement=")
+            .append(SystemStatementRedactor.redact(statement))
             .append("]");
         return sb.toString();
     }

--- a/driver/src/main/java/oracle/nosql/driver/ops/SystemResult.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/SystemResult.java
@@ -158,10 +158,12 @@ public class SystemResult extends Result {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("SystemResult [statement=").append(statement)
+        sb.append("SystemResult [statement=")
+            .append(SystemStatementRedactor.redact(statement))
             .append(", state=").append(state)
             .append(", operationId=").append(operationId)
-            .append(", resultString=").append(resultString).append("]");
+            .append(", resultString=")
+            .append(SystemStatementRedactor.redact(resultString)).append("]");
         return sb.toString();
     }
 
@@ -211,7 +213,7 @@ public class SystemResult extends Result {
                 throw new RequestTimeoutException(
                     waitMillis,
                     "Operation not completed within timeout: " +
-                    statement);
+                    SystemStatementRedactor.redact(statement));
             }
 
             /* delay */

--- a/driver/src/main/java/oracle/nosql/driver/ops/SystemStatementRedactor.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/SystemStatementRedactor.java
@@ -1,0 +1,132 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.ops;
+
+/**
+ * @hidden
+ */
+final class SystemStatementRedactor {
+
+    private static final String IDENTIFIED = "identified";
+    private static final String BY = "by";
+    private static final String REDACTED = "<redacted>";
+
+    private SystemStatementRedactor() {}
+
+    static String redact(String statement) {
+        if (statement == null) {
+            return null;
+        }
+        int redactStart = getSensitiveValueStart(statement);
+        if (redactStart < 0) {
+            return statement;
+        }
+        return statement.substring(0, redactStart) + REDACTED;
+    }
+
+    static String redact(char[] statement) {
+        if (statement == null) {
+            return null;
+        }
+        int redactStart = getSensitiveValueStart(statement);
+        if (redactStart < 0) {
+            return new String(statement);
+        }
+        return new String(statement, 0, redactStart) + REDACTED;
+    }
+
+    private static int getSensitiveValueStart(CharSequence statement) {
+        for (int i = 0; i < statement.length(); i++) {
+            int pos = matchWord(statement, i, IDENTIFIED);
+            if (pos < 0) {
+                continue;
+            }
+            pos = skipWhitespace(statement, pos);
+            pos = matchWord(statement, pos, BY);
+            if (pos < 0) {
+                continue;
+            }
+            return skipWhitespace(statement, pos);
+        }
+        return -1;
+    }
+
+    private static int getSensitiveValueStart(char[] statement) {
+        for (int i = 0; i < statement.length; i++) {
+            int pos = matchWord(statement, i, IDENTIFIED);
+            if (pos < 0) {
+                continue;
+            }
+            pos = skipWhitespace(statement, pos);
+            pos = matchWord(statement, pos, BY);
+            if (pos < 0) {
+                continue;
+            }
+            return skipWhitespace(statement, pos);
+        }
+        return -1;
+    }
+
+    private static int matchWord(CharSequence value, int offset, String word) {
+        int end = offset + word.length();
+        if (end > value.length()) {
+            return -1;
+        }
+        if (offset > 0 && isWordChar(value.charAt(offset - 1))) {
+            return -1;
+        }
+        for (int i = 0; i < word.length(); i++) {
+            if (Character.toLowerCase(value.charAt(offset + i)) !=
+                word.charAt(i)) {
+                return -1;
+            }
+        }
+        if (end < value.length() && isWordChar(value.charAt(end))) {
+            return -1;
+        }
+        return end;
+    }
+
+    private static int matchWord(char[] value, int offset, String word) {
+        int end = offset + word.length();
+        if (end > value.length) {
+            return -1;
+        }
+        if (offset > 0 && isWordChar(value[offset - 1])) {
+            return -1;
+        }
+        for (int i = 0; i < word.length(); i++) {
+            if (Character.toLowerCase(value[offset + i]) != word.charAt(i)) {
+                return -1;
+            }
+        }
+        if (end < value.length && isWordChar(value[end])) {
+            return -1;
+        }
+        return end;
+    }
+
+    private static int skipWhitespace(CharSequence value, int offset) {
+        while (offset < value.length() &&
+               Character.isWhitespace(value.charAt(offset))) {
+            offset++;
+        }
+        return offset;
+    }
+
+    private static int skipWhitespace(char[] value, int offset) {
+        while (offset < value.length && Character.isWhitespace(value[offset])) {
+            offset++;
+        }
+        return offset;
+    }
+
+    private static boolean isWordChar(char ch) {
+        return Character.isLetterOrDigit(ch) || ch == '_';
+    }
+}

--- a/driver/src/main/java/oracle/nosql/driver/util/HttpHeaderValidation.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/HttpHeaderValidation.java
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.util;
+
+/**
+ * @hidden
+ */
+public final class HttpHeaderValidation {
+
+    private HttpHeaderValidation() {}
+
+    public static void validateHttpHeaderValue(String fieldName,
+                                               String value) {
+        if (value == null) {
+            return;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch <= 0x1f || ch == 0x7f) {
+                throw new IllegalArgumentException(
+                    fieldName +
+                    " contains an invalid HTTP header value character " +
+                    "0x" + toHex(ch) + " at index " + i);
+            }
+        }
+    }
+
+    private static String toHex(char ch) {
+        String hex = Integer.toHexString(ch);
+        return (hex.length() == 1) ? "0" + hex : hex;
+    }
+}

--- a/driver/src/test/java/oracle/nosql/driver/HandleConfigTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/HandleConfigTest.java
@@ -9,10 +9,13 @@ package oracle.nosql.driver;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
+
+import oracle.nosql.driver.ops.GetRequest;
 
 import org.junit.Test;
 
@@ -107,6 +110,47 @@ public class HandleConfigTest {
                    arr.length > 2);
     }
 
+    @Test
+    public void testHttpHeaderValueValidation() {
+        NoSQLHandleConfig config = new NoSQLHandleConfig("http://foo.com");
+        GetRequest request = new GetRequest();
+
+        config.setDefaultCompartment("compartment.a");
+        assertEquals("compartment.a", config.getDefaultCompartment());
+        config.setDefaultNamespace("namespace_a");
+        assertEquals("namespace_a", config.getDefaultNamespace());
+        config.setExtensionUserAgent("app plugin/1.0");
+        assertEquals("app plugin/1.0", config.getExtensionUserAgent());
+        request.setCompartment("compartment.b");
+        assertEquals("compartment.b", request.getCompartment());
+        request.setNamespace("namespace_b");
+        assertEquals("namespace_b", request.getNamespace());
+
+        expectIllegalValue(() ->
+            config.setExtensionUserAgent("safe\r\nX-Injected: yes"));
+        expectIllegalValue(() ->
+            config.setExtensionUserAgent("safe\tunsafe"));
+        expectIllegalValue(() ->
+            config.setDefaultCompartment("compartment\nX-Injected: yes"));
+        expectIllegalValue(() ->
+            config.setDefaultNamespace("namespace\u0000unsafe"));
+        expectIllegalValue(() ->
+            request.setCompartment("compartment\rX-Injected: yes"));
+        expectIllegalValue(() ->
+            request.setNamespace("namespace\u007funsafe"));
+
+        config.setDefaultCompartment(null);
+        assertNull(config.getDefaultCompartment());
+        config.setDefaultNamespace(null);
+        assertNull(config.getDefaultNamespace());
+        config.setExtensionUserAgent(null);
+        assertNull(config.getExtensionUserAgent());
+        request.setCompartment(null);
+        assertNull(request.getCompartment());
+        request.setNamespace(null);
+        assertNull(request.getNamespace());
+    }
+
     private void expectIllegalArg(String endpoint) {
         try {
             new NoSQLHandleConfig(endpoint);
@@ -115,6 +159,15 @@ public class HandleConfigTest {
             // expect a failure
         }
 
+    }
+
+    private void expectIllegalValue(Runnable setter) {
+        try {
+            setter.run();
+            fail("Value should have failed validation");
+        } catch(IllegalArgumentException expected) {
+            // expect a failure
+        }
     }
 
     private void validate(String endpoint, String protocol,

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -8,7 +8,10 @@
 package oracle.nosql.driver;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import oracle.nosql.driver.ops.AddReplicaRequest;
+import oracle.nosql.driver.ops.DropReplicaRequest;
 import oracle.nosql.driver.ops.QueryRequest;
 
 import org.junit.Test;
@@ -24,5 +27,19 @@ public class RequestTest {
                      request.copyInternal().getDurability());
         assertEquals(Durability.COMMIT_SYNC,
                      request.copy().getDurability());
+    }
+
+    @Test
+    public void testReplicaRequestsDoNotRetryWithoutIdempotencyToken() {
+        RetryHandler handler = new DefaultRetryHandler(10, 0);
+        RetryableException retryable = new SystemException("retryable");
+
+        AddReplicaRequest addReplica = new AddReplicaRequest();
+        assertFalse(addReplica.shouldRetry());
+        assertFalse(handler.doRetry(addReplica, 0, retryable));
+
+        DropReplicaRequest dropReplica = new DropReplicaRequest();
+        assertFalse(dropReplica.shouldRetry());
+        assertFalse(handler.doRetry(dropReplica, 0, retryable));
     }
 }

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -9,10 +9,13 @@ package oracle.nosql.driver;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import oracle.nosql.driver.ops.AddReplicaRequest;
 import oracle.nosql.driver.ops.DropReplicaRequest;
 import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.SystemRequest;
+import oracle.nosql.driver.ops.SystemResult;
 
 import org.junit.Test;
 
@@ -41,5 +44,46 @@ public class RequestTest {
         DropReplicaRequest dropReplica = new DropReplicaRequest();
         assertFalse(dropReplica.shouldRetry());
         assertFalse(handler.doRetry(dropReplica, 0, retryable));
+    }
+
+    @Test
+    public void testSystemRequestAndResultToStringRedactPasswords() {
+        final String secret = "ChrisToph \"_12&%";
+        final String statement =
+            "CREATE USER u IDENTIFIED BY '" + secret + "'";
+        final String redactedStatement =
+            "CREATE USER u IDENTIFIED BY <redacted>";
+
+        SystemRequest request =
+            new SystemRequest().setStatement(statement.toCharArray());
+        assertTrue(request.toString().contains(redactedStatement));
+        assertFalse(request.toString().contains(secret));
+
+        SystemResult result = new SystemResult()
+            .setStatement(statement)
+            .setResultString("completed: " + statement)
+            .setState(SystemResult.State.COMPLETE);
+        String resultString = result.toString();
+        assertTrue(resultString.contains(redactedStatement));
+        assertFalse(resultString.contains(secret));
+
+        assertEquals(statement, result.getStatement());
+        assertEquals("completed: " + statement, result.getResultString());
+    }
+
+    @Test
+    public void testSystemToStringPreservesNonSensitiveStatements() {
+        final String statement = "CREATE NAMESPACE mynamespace";
+
+        SystemRequest request =
+            new SystemRequest().setStatement(statement.toCharArray());
+        assertTrue(request.toString().contains(statement));
+
+        SystemResult result = new SystemResult()
+            .setStatement(statement)
+            .setResultString("created namespace")
+            .setState(SystemResult.State.COMPLETE);
+        assertTrue(result.toString().contains(statement));
+        assertTrue(result.toString().contains("created namespace"));
     }
 }

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver;
+
+import static org.junit.Assert.assertEquals;
+
+import oracle.nosql.driver.ops.QueryRequest;
+
+import org.junit.Test;
+
+public class RequestTest {
+
+    @Test
+    public void testQueryRequestCopyPreservesDurability() {
+        QueryRequest request = new QueryRequest()
+            .setDurability(Durability.COMMIT_SYNC);
+
+        assertEquals(Durability.COMMIT_SYNC,
+                     request.copyInternal().getDurability());
+        assertEquals(Durability.COMMIT_SYNC,
+                     request.copy().getDurability());
+    }
+}

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -11,8 +11,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+
 import oracle.nosql.driver.ops.AddReplicaRequest;
 import oracle.nosql.driver.ops.DropReplicaRequest;
+import oracle.nosql.driver.ops.PreparedStatement;
 import oracle.nosql.driver.ops.QueryRequest;
 import oracle.nosql.driver.ops.SystemRequest;
 import oracle.nosql.driver.ops.SystemResult;
@@ -85,5 +88,44 @@ public class RequestTest {
             .setState(SystemResult.State.COMPLETE);
         assertTrue(result.toString().contains(statement));
         assertTrue(result.toString().contains("created namespace"));
+    }
+
+    @Test
+    public void testPreparedStatementDoesNotExposeMutableProxyBytes() {
+        ArrayList<byte[]> proxyStatements = new ArrayList<byte[]>();
+        byte[] proxyStatement = new byte[] {1, 2, 3};
+        proxyStatements.add(proxyStatement);
+        ArrayList<String> namespaces = new ArrayList<String>();
+        namespaces.add("ns");
+        ArrayList<String> tableNames = new ArrayList<String>();
+        tableNames.add("table");
+
+        PreparedStatement prepared = new PreparedStatement(
+            "select * from table",
+            null,
+            null,
+            proxyStatements,
+            null,
+            0,
+            0,
+            null,
+            namespaces,
+            tableNames,
+            (byte)5,
+            0);
+
+        proxyStatement[0] = 9;
+        proxyStatements.set(0, new byte[] {9, 9, 9});
+        assertEquals(1, prepared.getProxyStatement(0)[0]);
+
+        byte[] returned = prepared.getProxyStatement(0);
+        returned[0] = 8;
+        assertEquals(1, prepared.getProxyStatement(0)[0]);
+
+        PreparedStatement copy = prepared.copyStatement();
+        returned = copy.getProxyStatement(0);
+        returned[0] = 7;
+        assertEquals(1, copy.getProxyStatement(0)[0]);
+        assertEquals(1, prepared.getProxyStatement(0)[0]);
     }
 }


### PR DESCRIPTION
Fixed:
- Make prepared-query byte arrays immutable
- Redact sensitive information from SystemResult.toString() and SystemRequest.toString()
- Add/drop replica retries lack SDK idempotency token support
- Resource-scope header values can inject outbound HTTP headers
- Extension user-agent can inject outbound HTTP headers
- Internal query copies drop caller-specified durability for query DML
