### PR TITLE
Use Netty BOM and update SDK assembly for netty-tcnative artifacts

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -46,11 +46,13 @@
     <java.apidoc>https://docs.oracle.com/en/java/javase/11/docs/api/</java.apidoc>
     <maven.deploy.skip>false</maven.deploy.skip>
     <netty.version>4.1.135.Final</netty.version>
+    <!-- using the netty bom - netty maintainers regularly update the BOM to newer netty-tcnative releases
     <netty.tcnative.version>2.0.79.Final</netty.tcnative.version>
+    -->
     <jackson.version>2.18.7</jackson.version>
-   <!-- by default, skip tests; tests require a profile -->
-   <maven.test.skip>true</maven.test.skip>
-   <javac>javac</javac>
+    <!-- by default, skip tests; tests require a profile -->
+    <maven.test.skip>true</maven.test.skip>
+    <javac>javac</javac>
   </properties>
 
   <profiles>
@@ -219,6 +221,18 @@
     </profile>
 
   </profiles>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <!-- jackson core - JSON processing -->
@@ -232,27 +246,22 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty.tcnative.version}</version>
     </dependency>
 
     <!-- test -->

--- a/driver/src/main/assembly/sdk.xml
+++ b/driver/src/main/assembly/sdk.xml
@@ -45,8 +45,12 @@
 
   <dependencySets>
     <dependencySet>
-      <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
       <outputDirectory>lib</outputDirectory>
+      <!-- <outputFileNameMapping>${artifact.artifactId}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>-->
+      <outputFileNameMapping>${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+      <excludes>
+        <exclude>io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 


### PR DESCRIPTION
- Use the Netty BOM to manage Netty dependency versions.
- Add the required netty-tcnative artifacts to the SDK package for OpenSSL support.
- Update the assembly to preserve versioned JAR names, allowing multiple native artifacts to coexist without filename conflicts.

**Note**: If we ever need to pin netty-tcnative-boringssl-static to a specific version, we should manage the netty-tcnative versions explicitly instead of relying on the BOM so that all netty-tcnative artifacts remain on the same version.