### PR TITLE
Redact tokens from logs and exceptions

### DIFF
--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -841,16 +841,15 @@ public class Client {
                     kvRequest.incrementRetries();
                     exception = rae;
                     logFine(logger,
-                        "Client re-auth on AuthenticationException: " +
-                            rae.getMessage());
+                        "Client re-auth on AuthenticationException");
                     continue;
                 }
                 kvRequest.setRateLimitDelayedMs(rateDelayedMs);
                 statsControl.observeError(kvRequest);
                 logInfo(logger, "Unexpected authentication exception: " +
-                        rae);
-                throw new NoSQLException("Unexpected exception: " +
-                        rae.getMessage(), rae);
+                        rae.getClass().getSimpleName());
+                throw new NoSQLException("Unexpected authentication exception",
+                                         rae);
             } catch (InvalidAuthorizationException iae) {
                 /*
                  * Allow a single retry for invalid/expired auth
@@ -863,8 +862,7 @@ public class Client {
                     /* same as NoSQLException below */
                     kvRequest.setRateLimitDelayedMs(rateDelayedMs);
                     statsControl.observeError(kvRequest);
-                    logFine(logger, "Client execute NoSQLException: " +
-                            iae.getMessage());
+                    logFine(logger, "Client execute InvalidAuthorizationException");
                     throw iae;
                 }
                 /* flush auth cache and do one retry */
@@ -873,8 +871,7 @@ public class Client {
                 kvRequest.incrementRetries();
                 exception = iae;
                 logFine(logger,
-                        "Client retrying on InvalidAuthorizationException: " +
-                        iae.getMessage());
+                        "Client retrying on InvalidAuthorizationException");
                 continue;
             } catch (SecurityInfoNotReadyException sinre) {
                 kvRequest.addRetryException(sinre.getClass());

--- a/driver/src/main/java/oracle/nosql/driver/iam/AbstractTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/AbstractTokenSupplier.java
@@ -12,6 +12,7 @@ import static oracle.nosql.driver.iam.Utils.logTrace;
 import static oracle.nosql.driver.iam.Utils.parseTokenResponse;
 import static oracle.nosql.driver.iam.SecurityTokenSupplier.SecurityToken;
 import static oracle.nosql.driver.util.HttpRequestUtil.HttpResponse;
+import static oracle.nosql.driver.util.LogUtil.redactSensitiveValue;
 
 import javax.net.ssl.SSLException;
 import java.net.URI;
@@ -207,7 +208,8 @@ abstract class AbstractTokenSupplier
                                     ", status code: %d, output: %s",
                             resourcePrincipalTokenURI.getHost(),
                             resourcePrincipalTokenResponse.getStatusCode(),
-                            resourcePrincipalTokenResponse.getOutput()));
+                            redactSensitiveValue(
+                                resourcePrincipalTokenResponse.getOutput())));
         }
 
         return resourcePrincipalTokenResponse;
@@ -249,7 +251,8 @@ abstract class AbstractTokenSupplier
                                     ", status code: %d, output: %s",
                             federationURI.getHost(),
                             resourcePrincipalSessionTokenResponse.getStatusCode(),
-                            resourcePrincipalSessionTokenResponse.getOutput()));
+                            redactSensitiveValue(
+                                resourcePrincipalSessionTokenResponse.getOutput())));
         }
 
         String resourcePrincipalSessionToken = parseTokenResponse(

--- a/driver/src/main/java/oracle/nosql/driver/iam/FederationRequestHelper.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/FederationRequestHelper.java
@@ -10,6 +10,7 @@ package oracle.nosql.driver.iam;
 import static oracle.nosql.driver.iam.Utils.*;
 import static oracle.nosql.driver.util.HttpConstants.*;
 import static oracle.nosql.driver.util.LogUtil.logHeaderValue;
+import static oracle.nosql.driver.util.LogUtil.redactSensitiveValue;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -74,9 +75,10 @@ class FederationRequestHelper {
                     "Error getting security token from IAM, " +
                     "status code %d, response \n%s",
                     response.getStatusCode(),
-                    response.getOutput()));
+                    redactSensitiveValue(response.getOutput())));
         }
-        logTrace(logger, "Federation response " + response.getOutput());
+        logTrace(logger, "Federation response " +
+                 redactSensitiveValue(response.getOutput()));
         return parseTokenResponse(response.getOutput());
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/OkeWorkloadIdentityProvider.java
@@ -37,6 +37,7 @@ import oracle.nosql.driver.httpclient.HttpClient;
 import oracle.nosql.driver.iam.SessionKeyPairSupplier.DefaultSessionKeySupplier;
 import oracle.nosql.driver.util.HttpRequestUtil;
 import oracle.nosql.driver.util.NettySslContextUtil;
+import oracle.nosql.driver.util.LogUtil;
 import oracle.nosql.driver.values.FieldValue;
 import oracle.nosql.driver.values.MapValue;
 
@@ -244,16 +245,19 @@ class OkeWorkloadIdentityProvider
                 String.format(
                     "Error getting security token from Kubernetes proxymux, " +
                     "status code %d, opc-request-id %s, response\n%s",
-                    responseCode, requestId, responseOutput));
+                    responseCode, requestId,
+                    LogUtil.redactSensitiveValue(responseOutput)));
         }
 
         /* The encoded response is returned with quotation marks */
         responseOutput = responseOutput.replace("\"", "");
-        Utils.logTrace(logger, "Token response " + responseOutput);
+        Utils.logTrace(logger, "Token response " +
+                       LogUtil.redactSensitiveValue(responseOutput));
         final String decoded = new String(
             Base64.getDecoder().decode(responseOutput),
             StandardCharsets.UTF_8);
-        Utils.logTrace(logger, "Decoded Token " + decoded);
+        Utils.logTrace(logger, "Decoded Token " +
+                       LogUtil.redactSensitiveValue(decoded));
 
         /*
          * Kubernetes token has duplicated key id prefix "ST$" in the token

--- a/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SecurityTokenSupplier.java
@@ -291,7 +291,7 @@ class SecurityTokenSupplier implements TokenSupplier {
                 }
                 if (exp == null || expiryMS == -1) {
                     throw new IllegalArgumentException(
-                        "No expiration info in token:\n" + securityToken);
+                        "No expiration info in security token");
                 }
             }
 
@@ -304,9 +304,8 @@ class SecurityTokenSupplier implements TokenSupplier {
                      ", expiry=" + getExpiryMS() + ", creation=" +
                      getCreationTime());
             if (tokenLifetime < minTokenLifetime) {
-                logTrace(logger, "Security token has shorter lifetime" +
-                         "than expected minimal token lifetime, token:\n" +
-                         getSecurityToken());
+                logTrace(logger, "Security token has shorter lifetime " +
+                         "than expected minimal token lifetime");
             }
 
             /*
@@ -319,13 +318,11 @@ class SecurityTokenSupplier implements TokenSupplier {
 
             if (modulus == null) {
                 throw new IllegalArgumentException(
-                    "Invalid JWK, no modulus in token:\n" +
-                    securityToken);
+                    "Invalid JWK, no modulus in security token");
             }
             if (exponent == null) {
                 throw new IllegalArgumentException(
-                    "Invalid JWK, no exponent in token:\n" +
-                    securityToken);
+                    "Invalid JWK, no exponent in security token");
             }
             RSAPublicKey jwkRsa = Utils.toPublicKey(modulus, exponent);
             RSAPublicKey expected = (RSAPublicKey)
@@ -333,13 +330,11 @@ class SecurityTokenSupplier implements TokenSupplier {
 
             if (jwkRsa == null) {
                 throw new IllegalArgumentException(
-                    "Invalid JWK, unable to find public key in token:\n" +
-                    securityToken);
+                    "Invalid JWK, unable to find public key in security token");
             }
             if (!isEqualPublicKey(jwkRsa, expected)) {
                 throw new IllegalArgumentException(
-                    "Invalid JWK, public key not match in token:\n" +
-                    securityToken);
+                    "Invalid JWK, public key does not match security token");
             }
         }
 

--- a/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/SignatureProvider.java
@@ -1028,8 +1028,7 @@ public class SignatureProvider
 
         if (dot1 == -1 || dot2 == -1 || dot3 != -1) {
             throw new IllegalArgumentException(
-                "Given string is not in the valid JWT token format\n" +
-                token);
+                "Given string is not in the valid JWT token format");
         }
         this.delegationToken = token;
     }

--- a/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
+++ b/driver/src/main/java/oracle/nosql/driver/iam/Utils.java
@@ -52,6 +52,7 @@ import javax.security.auth.x500.X500Principal;
 import oracle.nosql.driver.iam.pki.Pem;
 import oracle.nosql.driver.Region;
 import oracle.nosql.driver.iam.CertificateSupplier.X509CertificateKeyPair;
+import oracle.nosql.driver.util.LogUtil;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -532,11 +533,12 @@ class Utils {
                 }
             }
             throw new IllegalStateException(
-                "Unable to find security token in " + response);
+                "Unable to find security token in response " +
+                LogUtil.redactSensitiveValue(response));
         } catch (IOException ioe) {
             throw new IllegalStateException(
-                "Error parsing security token " + response +
-                    " " + ioe.getMessage());
+                "Error parsing security token response " +
+                LogUtil.redactSensitiveValue(response));
         }
     }
 
@@ -563,13 +565,14 @@ class Utils {
             }
             if(results.isEmpty()) {
                 throw new IllegalStateException(
-                        "Unable to find resource principal tokens in " + response);
+                        "Unable to find resource principal tokens in response " +
+                        LogUtil.redactSensitiveValue(response));
             }
             return results;
         } catch (IOException ioe) {
             throw new IllegalStateException(
-                    "Error parsing resource principal tokens " + response +
-                            " " + ioe.getMessage());
+                    "Error parsing resource principal token response " +
+                    LogUtil.redactSensitiveValue(response));
         }
     }
 

--- a/driver/src/main/java/oracle/nosql/driver/kv/StoreAccessTokenProvider.java
+++ b/driver/src/main/java/oracle/nosql/driver/kv/StoreAccessTokenProvider.java
@@ -271,7 +271,8 @@ public class StoreAccessTokenProvider implements AuthorizationProvider {
              */
             if (response.getStatusCode() != HttpResponseStatus.OK.code()) {
                 throw new InvalidAuthorizationException(
-                    "Fail to login to service: " + response.getOutput());
+                    "Fail to login to service (status " +
+                    response.getStatusCode() + ")");
             }
 
             if (isClosed) {
@@ -358,13 +359,13 @@ public class StoreAccessTokenProvider implements AuthorizationProvider {
             if (response.getStatusCode() != HttpResponseStatus.OK.code()) {
                 if (logger != null) {
                     logger.info("Failed to logout user " + userName +
-                                ": " + response.getOutput());
+                                " (status " + response.getStatusCode() + ")");
                 }
             }
         } catch (Exception e) {
             if (logger != null) {
-                logger.info("Failed to logout user " + userName +
-                            ": " + e);
+                logger.info("Failed to logout user " + userName + ": " +
+                            e.getClass().getSimpleName());
             }
         }
 
@@ -603,7 +604,8 @@ public class StoreAccessTokenProvider implements AuthorizationProvider {
                 scheduleRefresh();
             } catch (Exception e) {
                 if (logger != null) {
-                    logger.info("Failed to renew login token: " + e);
+                    logger.info("Failed to renew login token: " +
+                                e.getClass().getSimpleName());
                 }
 
                 if (timer != null) {

--- a/driver/src/main/java/oracle/nosql/driver/util/LogUtil.java
+++ b/driver/src/main/java/oracle/nosql/driver/util/LogUtil.java
@@ -174,6 +174,14 @@ public class LogUtil {
         return REDACTED;
     }
 
+    /**
+     * Returns a safe representation of a value known to contain credentials,
+     * such as an authentication response body or a security token.
+     */
+    public static String redactSensitiveValue(String value) {
+        return REDACTED;
+    }
+
     private static boolean isSensitiveHeader(String headerName) {
         return headerName != null &&
                SENSITIVE_HEADERS.contains(

--- a/driver/src/test/java/oracle/nosql/driver/iam/TokenRedactionTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/iam/TokenRedactionTest.java
@@ -1,0 +1,49 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.iam;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class TokenRedactionTest {
+
+    @Test
+    public void testTokenResponseParseFailuresDoNotExposeResponse() {
+        final String response = "{\"unexpected\":\"secret-token\"}";
+
+        assertRedacted(() -> Utils.parseTokenResponse(response), response);
+        assertRedacted(() -> Utils.parseResourcePrincipalTokenResponse(response),
+                       response);
+    }
+
+    @Test
+    public void testMalformedTokenResponseDoesNotExposeResponseInCause() {
+        final String response = "{secret-token";
+
+        assertRedacted(() -> Utils.parseTokenResponse(response), response);
+        assertRedacted(() -> Utils.parseResourcePrincipalTokenResponse(response),
+                       response);
+    }
+
+    private void assertRedacted(ThrowingRunnable runnable, String secret) {
+        try {
+            runnable.run();
+            fail("Expected token parsing failure");
+        } catch (IllegalStateException ise) {
+            assertFalse(ise.getMessage().contains(secret));
+            assertFalse(ise.getMessage().contains("secret-token"));
+            assertFalse(ise.getCause() != null);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run();
+    }
+}

--- a/driver/src/test/java/oracle/nosql/driver/util/LogUtilTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/util/LogUtilTest.java
@@ -34,6 +34,13 @@ public class LogUtilTest {
     }
 
     @Test
+    public void testRedactSensitiveValue() {
+        assertEquals("<redacted>",
+                     LogUtil.redactSensitiveValue("secret-token"));
+        assertEquals("<redacted>", LogUtil.redactSensitiveValue(null));
+    }
+
+    @Test
     public void testFormatHeadersForLogRedactsSensitiveHeaders() {
         final HttpHeaders headers = new DefaultHttpHeaders();
         headers.add(HttpConstants.AUTHORIZATION, "Bearer secret-token");


### PR DESCRIPTION
  - Redacted IAM/Oke/resource-principal token responses in exceptions and FINE logs.
  - Removed raw security/delegation token values from validation errors and logs.
  - Prevented on-prem login/renew/logout paths and HTTP retry logs from emitting token-bearing exception text.
  - Added regression tests for redacted token-response parse failures.