### PR TITLE
Fix NPE from union branch lookup before query computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Resource-scope header values can inject outbound HTTP headers
 - Extension user-agent can inject outbound HTTP headers
 - Internal query copies drop caller-specified durability for query DML
+- Fixed an NPE during automatic auth refresh when processing the initial prepare
+  response for an advanced query.
 
 ## [5.4.23] 2026-06-26
 
@@ -33,7 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Added redaction of sensitive HTTP header values in debug logging by default,
   plus the `com.oracle.nosql.sdk.nosqldriver.log-sensitive-headers` system
   property to allow full header values when needed for debugging.
-  
+
 ### Fixed
 - Fixed bug in handling of empty namespaces in prepared statements.
 

--- a/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
@@ -94,7 +94,7 @@ public class QueryDriver {
     }
 
     public int getUnionBranch() {
-        return theRCB.getUnionBranch();
+        return theRCB == null ? 0 : theRCB.getUnionBranch();
     }
 
     /**

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -19,6 +19,7 @@ import oracle.nosql.driver.ops.PreparedStatement;
 import oracle.nosql.driver.ops.QueryRequest;
 import oracle.nosql.driver.ops.SystemRequest;
 import oracle.nosql.driver.ops.SystemResult;
+import oracle.nosql.driver.query.QueryDriver;
 
 import org.junit.Test;
 
@@ -127,5 +128,36 @@ public class RequestTest {
         returned[0] = 7;
         assertEquals(1, copy.getProxyStatement(0)[0]);
         assertEquals(1, prepared.getProxyStatement(0)[0]);
+    }
+
+    @Test
+    public void testQueryRequestMetadataBeforeDriverComputation() {
+        ArrayList<byte[]> proxyStatements = new ArrayList<byte[]>();
+        proxyStatements.add(new byte[] {1});
+        ArrayList<String> namespaces = new ArrayList<String>();
+        namespaces.add("ns");
+        ArrayList<String> tableNames = new ArrayList<String>();
+        tableNames.add("table");
+
+        PreparedStatement prepared = new PreparedStatement(
+            "select count(*) from table",
+            null,
+            null,
+            proxyStatements,
+            null,
+            0,
+            0,
+            null,
+            namespaces,
+            tableNames,
+            (byte)5,
+            0);
+        QueryRequest request =
+            new QueryRequest().setPreparedStatement(prepared);
+
+        new QueryDriver(request);
+
+        assertEquals("ns", request.getNamespace());
+        assertEquals("table", request.getTableName());
     }
 }


### PR DESCRIPTION
[QueryRequest.getTableName()](https://github.com/oracle/nosql-java-sdk/blob/main/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java#L1035) can call [QueryDriver.getUnionBranch()](https://github.com/oracle/nosql-java-sdk/blob/main/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java#L97) before the `RuntimeControlBlock` is initialized.  The `RuntimeControlBlock` is initialized when application starts read the results which calls [QueryDriver.compute()](https://github.com/oracle/nosql-java-sdk/blob/main/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java#L136). 

This can cause automatic auth refresh to fail with an NPE after an advanced query's initial prepare response.

Return branch 0 before RuntimeControlBlock initialization and add regression coverage for query metadata lookup before computation.