### PR TITLE
Add per-store topology support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+- Added per-store topology tracking so advanced queries routed through a proxy
+  serving multiple stores use the correct store's shard topology.
+
 ### Changed
 - Changed SSL/TLS to use netty-tcnative-boringssl-static to enable
   more secure cyphers/protocols including ML-KEM

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -146,7 +146,8 @@
           ConfigFileTest.java, SignatureProviderTest.java, AuthRetryTest.java,
           UserProfileProviderTest.java, InstancePrincipalsProviderTest.java,
           HandleConfigTest.java, JsonTest.java, ValueTest.java,
-          SessionTokenProviderTest.java, RequestTest.java
+          SessionTokenProviderTest.java, RequestTest.java,
+          RuntimeControlBlockTest.java
         </included.tests>
       </properties>
     </profile>

--- a/driver/src/main/java/oracle/nosql/driver/Nson.java
+++ b/driver/src/main/java/oracle/nosql/driver/Nson.java
@@ -436,7 +436,10 @@ public class Nson {
         if (nson == null) {
             return null;
         }
-        JsonSerializer jsonSerializer = new JsonSerializer(options);
+        JsonSerializer jsonSerializer =
+            (options != null && options.getPrettyPrint()) ?
+                new JsonPrettySerializer(options) :
+                new JsonSerializer(options);
         try (NettyByteInputStream bis =
              NettyByteInputStream.createFromBytes(nson)) {
             Nson.generateEventsFromNson(jsonSerializer, bis, false);

--- a/driver/src/main/java/oracle/nosql/driver/http/Client.java
+++ b/driver/src/main/java/oracle/nosql/driver/http/Client.java
@@ -43,8 +43,11 @@ import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -229,6 +232,9 @@ public class Client {
 
     private volatile TopologyInfo topology;
 
+    /* Per store topology */
+    private final Map<String, TopologyInfo> storeTopologies;
+
     /* for internal testing */
     private final String prepareFilename;
 
@@ -300,6 +306,7 @@ public class Client {
         }
 
         oneTimeMessages = new HashSet<String>();
+        storeTopologies = new ConcurrentHashMap<String, TopologyInfo>();
         statsControl = new StatsControlImpl(config,
             logger, httpClient, httpConfig.getRateLimitingEnabled());
 
@@ -360,6 +367,8 @@ public class Client {
         if (threadPool != null) {
             threadPool.shutdown();
         }
+        topology = null;
+        storeTopologies.clear();
     }
 
     public int getAcquiredChannelCount() {
@@ -441,9 +450,11 @@ public class Client {
 
             QueryRequest qreq = (QueryRequest)kvRequest;
 
-            /* Set the topo seq num in the request, if it has not been set
-             * already */
-            kvRequest.setTopoSeqNum(getTopoSeqNum());
+            /*
+             * Stamp the query request with the cached legacy topology sequence
+             * and the per-store topology sequences.
+             */
+            setRequestTopology(kvRequest);
 
             statsControl.observeQuery(qreq);
 
@@ -655,11 +666,15 @@ public class Client {
                  */
                 kvRequest.setCheckRequestSize(false);
 
-                /* Set the topo seq num in the request, if it has not been set
-                 * already */
+                /*
+                 * Stamp non-query and user query requests with the legacy
+                 * topology sequence and the per-store topology sequences
+                 * before serialization. The request preserves any topology
+                 * captured earlier for a query execution.
+                 */
                 if (!(kvRequest instanceof QueryRequest) ||
                     kvRequest.isQueryRequest()) {
-                    kvRequest.setTopoSeqNum(getTopoSeqNum());
+                    setRequestTopology(kvRequest);
                 }
 
                 /*
@@ -776,7 +791,8 @@ public class Client {
                 long networkLatency =
                     (System.nanoTime() - latencyNanos) / 1_000_000;
 
-                setTopology(res.getTopology());
+                /* Update cached legacy or per-store topology from the response. */
+                updateCachedTopology(res);
 
                 if (serialVersionUsed < 3) {
                     /* so we can emit a one-time message if the app */
@@ -1189,8 +1205,8 @@ public class Client {
         int durationSeconds = Integer.getInteger("test.rldurationsecs", 30)
                                      .intValue();
 
-        double RUs = (double)limits.getReadUnits();
-        double WUs = (double)limits.getWriteUnits();
+        double RUs = limits.getReadUnits();
+        double WUs = limits.getWriteUnits();
 
         /* if there's a specified rate limiter percentage, use that */
         double rlPercent = config.getDefaultRateLimitingPercentage();
@@ -1412,7 +1428,6 @@ public class Client {
         if (space <= 0) {
             space = v.length();
         }
-        long val = 0;
         try {
             this.features = Long.parseLong(v, eq+1, space, 16);
         } catch (Exception e) {
@@ -2040,6 +2055,68 @@ public class Client {
 
     public TopologyInfo getTopology() {
         return topology;
+    }
+
+    /**
+     * @hidden
+     * Returns an immutable snapshot of the per-store topology cache.
+     */
+    public Map<String, TopologyInfo> getStoreTopoSnapshot() {
+        return Collections.unmodifiableMap(new HashMap<>(storeTopologies));
+    }
+
+    /*
+     * Sets both the legacy topology sequence and a snapshot of the per-store
+     * topology sequences on the request before serialization. Both are set
+     * because the client cannot determine whether the proxy supports per-store
+     * topology sequences.
+     */
+    private void setRequestTopology(Request kvRequest) {
+        /* legacy topology sequence */
+        kvRequest.setTopoSeqNum(getTopoSeqNum());
+
+        /* per store topology sequence */
+        Map<String, TopologyInfo> topos = getStoreTopoSnapshot();
+        Map<String, Integer> seqNums = new HashMap<>();
+        for (Map.Entry<String, TopologyInfo> e : topos.entrySet()) {
+            seqNums.put(e.getKey(), e.getValue().getSeqNum());
+        }
+        kvRequest.setStoreTopoSeqNums(seqNums);
+    }
+
+    /*
+     * Updates the cached topology information:
+     *   - Updates the per-store cache from a response that carries per-store
+     *     topology information, retaining a newer cached sequence for each
+     *     store.
+     *   - Responses without per-store information update the legacy topology.
+     */
+    private void updateCachedTopology(Result ret) {
+        if (ret.getStoreTopologies() != null) {
+            setPerStoreTopology(ret.getStoreTopologies());
+            return;
+        }
+
+        setTopology(ret.getTopology());
+    }
+
+    private void setPerStoreTopology(List<TopologyInfo> storeTopos) {
+
+        if (storeTopos == null) {
+            return;
+        }
+
+        for (TopologyInfo topo : storeTopos) {
+            storeTopologies.compute(
+                topo.getStoreName(), (storeName, currentTopo) -> {
+                    if (currentTopo == null ||
+                        currentTopo.getSeqNum() < topo.getSeqNum()) {
+                        trace("New store topology: " + topo, 1);
+                        return topo;
+                    }
+                    return currentTopo;
+                });
+        }
     }
 
     private synchronized int getTopoSeqNum() {

--- a/driver/src/main/java/oracle/nosql/driver/ops/PreparedStatement.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/PreparedStatement.java
@@ -96,6 +96,13 @@ public class PreparedStatement {
     private final ArrayList<String> topTableNames;
 
     /*
+     * The store names returned from a prepared query result. When present,
+     * this is branch-aligned with proxyStatements. Null means legacy plan
+     * metadata without per-store branch identity.
+     */
+    private final ArrayList<String> branchStoreNames;
+
+    /*
      * the operation code for the query.
      */
     private final byte operation;
@@ -136,6 +143,8 @@ public class PreparedStatement {
      * @param operation operation code for the query
      * @param maxParallelism the maximum degree of parallelism possible for the
      * query
+     * @param branchStoreNames optional store names aligned with each proxy
+     * statement. Null means legacy plan metadata.
      * @hidden
      */
     public PreparedStatement(
@@ -150,7 +159,8 @@ public class PreparedStatement {
         ArrayList<String> namespaces,
         ArrayList<String> tableNames,
         byte operation,
-        int maxParallelism) {
+        int maxParallelism,
+        ArrayList<String> branchStoreNames) {
 
         if (proxyStatements == null || proxyStatements.isEmpty()) {
             throw new IllegalArgumentException(
@@ -169,6 +179,7 @@ public class PreparedStatement {
         this.topTableNames = tableNames;
         this.operation = operation;
         this.maxParallelism = maxParallelism;
+        this.branchStoreNames = branchStoreNames;
     }
 
     /**
@@ -191,7 +202,8 @@ public class PreparedStatement {
                                      namespaces,
                                      topTableNames,
                                      operation,
-                                     maxParallelism);
+                                     maxParallelism,
+                                     branchStoreNames);
     }
 
     /**
@@ -330,6 +342,15 @@ public class PreparedStatement {
         return proxyStatements.get(branch).clone();
     }
 
+    /**
+     * Internal use only
+     * @return the number of proxy-side query branches in this statement
+     * @hidden
+     */
+    public int getNumBranches() {
+        return proxyStatements.size();
+    }
+
     private static ArrayList<byte[]> copyProxyStatements(
         ArrayList<byte[]> source) {
 
@@ -432,6 +453,18 @@ public class PreparedStatement {
      */
     public String getTopTableName(int branch) {
         return topTableNames.get(branch);
+    }
+
+    /**
+     * Internal use only
+     * @return store name from prepared statement if any
+     * @hidden
+     */
+    public String getBranchStoreName(int branch) {
+        if (branchStoreNames == null) {
+            return null;
+        }
+        return branchStoreNames.get(branch);
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/QueryRequest.java
@@ -208,6 +208,23 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
     }
 
     /**
+     * Updates this request's topology with the snapshot selected for an
+     * advanced query execution. This is called only after the
+     * {@link QueryDriver} has selected the base topologies.
+     *
+     * @param topoSeqNum the legacy topology sequence number, or {@code -1}
+     * if no legacy topology is available
+     * @param storeTopoSeqNums the per-store topology sequences
+     * @hidden
+     */
+    public void setExecutionTopology(int topoSeqNum,
+                                     Map<String, Integer> storeTopoSeqNums) {
+
+        this.topoSeqNum = topoSeqNum;
+        this.storeTopoSeqNums = storeTopoSeqNums;
+    }
+
+    /**
      * Creates an internal QueryRequest out of the application-provided request.
      * @return a copy of the instance in a new object
      * @hidden
@@ -233,6 +250,7 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
         internalReq.isInternal = true;
         internalReq.driver = driver;
         internalReq.topoSeqNum = topoSeqNum;
+        internalReq.storeTopoSeqNums = storeTopoSeqNums;
         internalReq.inTestMode = inTestMode;
         internalReq.operationNumber = operationNumber;
         internalReq.numberOfOperations = numberOfOperations;
@@ -1147,7 +1165,7 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
         }
         /*
          * Parallel queries have multiple requirements:
-         * o only for prepared queries
+         * o only for simple prepared queries
          * o if set, both number of operations and op number need to be set
          * o operation number must be <= number of operations
          * o number of operations must be <= the max
@@ -1158,6 +1176,11 @@ public class QueryRequest extends DurableRequest implements AutoCloseable {
             if (!isPrepared()) {
                 throw new IllegalArgumentException(
                     "Parallel queries are only allowed on prepared queries");
+            }
+            if (!isSimpleQuery()) {
+                throw new IllegalArgumentException(
+                    "Parallel queries are only allowed on simple " +
+                    "prepared queries");
             }
             /* check both non-zero and value of operation number */
             if (getOperationNumber() > getNumberOfOperations() ||

--- a/driver/src/main/java/oracle/nosql/driver/ops/Request.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Request.java
@@ -9,6 +9,8 @@ package oracle.nosql.driver.ops;
 
 import static oracle.nosql.driver.util.HttpHeaderValidation.validateHttpHeaderValue;
 
+import java.util.Map;
+
 import oracle.nosql.driver.NoSQLHandleConfig;
 import oracle.nosql.driver.RateLimiter;
 import oracle.nosql.driver.ops.serde.Serializer;
@@ -84,6 +86,14 @@ public abstract class Request {
     private boolean isRefresh;
 
     protected int topoSeqNum = -1;
+
+    /**
+     * @hidden
+     * Per-store topology sequences serialized as request header h.sts. The
+     * client initializes this map before sending a request. An empty map
+     * advertises per-store topology support with no cached store topology.
+     */
+    protected Map<String, Integer> storeTopoSeqNums;
 
     /**
      * @hidden
@@ -533,6 +543,27 @@ public abstract class Request {
         if (topoSeqNum < 0) {
             topoSeqNum = n;
         }
+    }
+
+    /**
+     * internal use only
+     * @return the per-store topology sequences for request
+     * @hidden
+     */
+    public Map<String, Integer> getStoreTopoSeqNums() {
+        return storeTopoSeqNums;
+    }
+
+    /**
+     * internal use only
+     * @param topoSeqNums the per-store topology sequences
+     * @hidden
+     */
+    public void setStoreTopoSeqNums(Map<String, Integer> topoSeqNums) {
+        if (storeTopoSeqNums != null) {
+            return;
+        }
+        storeTopoSeqNums = topoSeqNums;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/Result.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/Result.java
@@ -7,6 +7,8 @@
 
 package oracle.nosql.driver.ops;
 
+import java.util.List;
+
 import oracle.nosql.driver.query.TopologyInfo;
 
 /**
@@ -45,7 +47,11 @@ public class Result {
      */
     private RetryStats retryStats;
 
+    /* Topology returned by the legacy single-topology protocol. */
     private TopologyInfo topology;
+
+    /* Per-store topology entries returned by the per-store protocol. */
+    private List<TopologyInfo> storeTopologies;
 
     protected Result() {}
 
@@ -179,6 +185,24 @@ public class Result {
      */
     public void setTopology(TopologyInfo ti) {
         topology = ti;
+    }
+
+    /**
+     * internal use only
+     * @return per-store topology information
+     * @hidden
+     */
+    public List<TopologyInfo> getStoreTopologies() {
+        return storeTopologies;
+    }
+
+    /**
+     * internal use only
+     * @param topologies per-store topology information
+     * @hidden
+     */
+    public void setStoreTopologies(List<TopologyInfo> topologies) {
+        storeTopologies = topologies;
     }
 
     /**

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/PrepareRequestSerializer.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/PrepareRequestSerializer.java
@@ -172,7 +172,8 @@ public class PrepareRequestSerializer extends BinaryProtocol
                                   namespaces,
                                   tableNames,
                                   operation,
-                                  0); /* no parallelism available */
+                                  0,     /* no parallelism available */
+                                  null); /* branchStoreNames */
 
         result.setPreparedStatement(prep);
         result.setTopology(ti);

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonProtocol.java
@@ -76,6 +76,7 @@ public class NsonProtocol {
     public static String PREPARED_STATEMENT = "ps";
     public static String QUERY = "q";
     public static String QUERY_BRANCHES = "qb";
+    public static String QUERY_BRANCH_STORES = "qbs";
     public static String QUERY_NAME = "qn";
     public static String QUERY_OPERATION_NUM = "on";
     public static String QUERY_VERSION = "qv";
@@ -89,9 +90,11 @@ public class NsonProtocol {
     public static String RETURN_ROW = "rr";
     public static String SERVER_MEMORY_CONSUMPTION = "sm";
     public static String SHARD_ID = "si";
+    public static String STORE_TOPO_SEQ_NUMS = "sts";
     public static String START = "sr";
     public static String STATEMENT = "st";
     public static String STORAGE_THROTTLE_COUNT = "sl";
+    public static String STORE_ID = "sid";
     public static String SYSTEM = "sy";
     public static String TABLES = "tb";
     public static String TABLE_DDL = "td";
@@ -138,6 +141,7 @@ public class NsonProtocol {
     public static String SHARD_IDS = "sa";
     public static String SUCCESS = "ss";
     public static String TOPOLOGY_INFO = "tp";
+    public static String STORE_TOPOLOGY_INFO = "stp";
     public static String WM_FAILURE = "wf";
     public static String WM_FAIL_INDEX = "wi";
     public static String WM_FAIL_RESULT = "wr";
@@ -253,6 +257,7 @@ public class NsonProtocol {
         {PREPARED_STATEMENT,"PREPARED_STATEMENT"},
         {QUERY,"QUERY"},
         {QUERY_BRANCHES,"QUERY_BRANCHES"},
+        {QUERY_BRANCH_STORES,"QUERY_BRANCH_STORES"},
         {QUERY_NAME,"QUERY_NAME"},
         {QUERY_OPERATION_NUM,"QUERY_OPERATION_NUM"},
         {QUERY_VERSION,"QUERY_VERSION"},
@@ -266,9 +271,11 @@ public class NsonProtocol {
         {RETURN_ROW,"RETURN_ROW"},
         {SERVER_MEMORY_CONSUMPTION,"SERVER_MEMORY_CONSUMPTION"},
         {SHARD_ID,"SHARD_ID"},
+        {STORE_TOPO_SEQ_NUMS,"STORE_TOPO_SEQ_NUMS"},
         {START,"START"},
         {STATEMENT,"STATEMENT"},
         {STORAGE_THROTTLE_COUNT,"STORAGE_THROTTLE_COUNT"},
+        {STORE_ID,"STORE_ID"},
         {SYSTEM,"SYSTEM"},
         {TABLES,"TABLES"},
         {TABLE_DDL,"TABLE_DDL"},
@@ -311,6 +318,7 @@ public class NsonProtocol {
         {SHARD_IDS,"SHARD_IDS"},
         {SUCCESS,"SUCCESS"},
         {TOPOLOGY_INFO,"TOPOLOGY_INFO"},
+        {STORE_TOPOLOGY_INFO,"STORE_TOPOLOGY_INFO"},
         {WM_FAILURE,"WM_FAILURE"},
         {WM_FAIL_INDEX,"WM_FAIL_INDEX"},
         {WM_FAIL_RESULT,"WM_FAIL_RESULT"},

--- a/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
+++ b/driver/src/main/java/oracle/nosql/driver/ops/serde/nson/NsonSerializerFactory.java
@@ -111,6 +111,13 @@ import oracle.nosql.driver.values.FieldValue;
 import oracle.nosql.driver.values.MapValue;
 
 public class NsonSerializerFactory implements SerializerFactory {
+
+    /* Maximum number of stores. */
+    private static final int MAX_STORES = 10_000;
+
+    /* Maximum number of query branches. */
+    private static final int MAX_QUERY_BRANCHES = 10_000;
+
     static private NsonSerializerFactory factory = new NsonSerializerFactory();
 
     /* return the singleton */
@@ -502,6 +509,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                     readRow(in, result);
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, result);
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, result);
                 } else {
                     skipUnknownField(walker, name);
                 }
@@ -579,6 +588,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                     readReturnInfo(in, result);
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, result);
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, result);
                 } else {
                     skipUnknownField(walker, name);
                 }
@@ -673,6 +684,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                     result.setContinuationKey(Nson.readNsonBinary(in));
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, result);
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, result);
                 } else {
                     skipUnknownField(walker, name);
                 }
@@ -758,6 +771,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                     result.setGeneratedValue(Nson.readFieldValue(in));
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, result);
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, result);
                 } else {
                     skipUnknownField(walker, name);
                 }
@@ -875,8 +890,8 @@ public class NsonSerializerFactory implements SerializerFactory {
             if (isPrepared) {
                 QueryDriver driver = rq.getDriver();
                 int unionBranch = (driver != null ? driver.getUnionBranch() : 0);
-                byte[] proxyPlan = rq.getPreparedStatement().
-                                      getProxyStatement(unionBranch);
+                PreparedStatement pstmt = rq.getPreparedStatement();
+                byte[] proxyPlan = pstmt.getProxyStatement(unionBranch);
                 writeMapField(ns, IS_PREPARED, isPrepared);
                 writeMapField(ns, IS_SIMPLE_QUERY, rq.isSimpleQuery());
                 writeMapField(ns, PREPARED_QUERY, proxyPlan);
@@ -892,6 +907,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                 }
                 writeBindVariables(ns, out,
                               rq.getPreparedStatement().getVariables());
+                writeMapField(ns, STORE_ID,
+                              pstmt.getBranchStoreName(unionBranch));
             } else {
                 writeMapField(ns, STATEMENT, rq.getStatement());
             }
@@ -1015,6 +1032,8 @@ public class NsonSerializerFactory implements SerializerFactory {
             ArrayList<String> namespaces = new ArrayList<>();
             ArrayList<String> tableNames = new ArrayList<>();
             ArrayList<byte[]> proxyPreparedQueries = new ArrayList<>();
+            ArrayList<String> branchStores = null;
+            int numBranches = -1;
 
             DriverPlanInfo dpi = null;
             String queryPlan = null;
@@ -1054,8 +1073,7 @@ public class NsonSerializerFactory implements SerializerFactory {
                 } else if (name.equals(QUERY_BRANCHES)) {
                     readType(in, Nson.TYPE_ARRAY);
                     in.readInt(); /* length of array in bytes */
-                    int numBranches = in.readInt(); /* number of array elements */
-
+                    numBranches = readBranchCount(in, QUERY_BRANCHES);
                     for (int i = 0; i < numBranches; ++i) {
                         MapWalker walker2 = getMapWalker(in);
                         while (walker2.hasNext()) {
@@ -1074,6 +1092,9 @@ public class NsonSerializerFactory implements SerializerFactory {
                             }
                         }
                     }
+
+                } else if (name.equals(QUERY_BRANCH_STORES)) {
+                    branchStores = readQueryStoreNames(in);
 
                 } else if (name.equals(DRIVER_QUERY_PLAN)) {
                     dpi = getDriverPlanInfo(Nson.readNsonBinary(in),
@@ -1096,6 +1117,9 @@ public class NsonSerializerFactory implements SerializerFactory {
 
                 } else if (name.equals(QUERY_OPERATION)) {
                     operation = (byte)Nson.readNsonInt(in);
+
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, (qres != null ? qres : pres));
 
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, (qres != null ? qres : pres));
@@ -1142,6 +1166,12 @@ public class NsonSerializerFactory implements SerializerFactory {
                 res.setTopology(new TopologyInfo(proxyTopoSeqNum, shardIds));
             }
 
+            if (branchStores != null && branchStores.size() != numBranches) {
+                throw new IllegalArgumentException(
+                    "Invalid prepared query: QUERY_BRANCH_STORES count does " +
+                    "not match QUERY_BRANCHES count");
+            }
+
             if (qres != null) {
                 qres.setContinuationKey(contKey);
                 qreq.setContKey(qres.getContinuationKey());
@@ -1171,7 +1201,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                                          namespaces,
                                          tableNames,
                                          operation,
-                                         maxParallelism);
+                                         maxParallelism,
+                                         branchStores);
             if (pres != null) {
                 pres.setPreparedStatement(prep);
             } else if (qreq != null) {
@@ -1182,6 +1213,44 @@ public class NsonSerializerFactory implements SerializerFactory {
                     qres.setComputed(false);
                 }
             }
+        }
+
+        /*
+         * Reads the store name for each query branch. Entry i identifies the
+         * store for branch i, so duplicate store names are valid.
+         *
+         * QUERY_BRANCH_STORES: [string, ...]
+         */
+        private static ArrayList<String> readQueryStoreNames(ByteInputStream in)
+            throws IOException {
+
+            readType(in, Nson.TYPE_ARRAY);
+            in.readInt(); /* length of array in bytes */
+
+            int numBranches = readBranchCount(in, QUERY_BRANCH_STORES);
+
+            ArrayList<String> storeNames = new ArrayList<>(numBranches);
+            for (int i = 0; i < numBranches; ++i) {
+                String storeName = Nson.readNsonString(in);
+                if (storeName == null || storeName.isBlank()) {
+                    throw new IllegalArgumentException(
+                        "Invalid prepared query: empty branch STORE_ID");
+                }
+                storeNames.add(storeName);
+            }
+            return storeNames;
+        }
+
+        private static int readBranchCount(ByteInputStream in, String field)
+            throws IOException {
+
+            int numBranches = in.readInt();
+            if (numBranches < 0 || numBranches > MAX_QUERY_BRANCHES) {
+                throw new IllegalArgumentException(
+                    "Invalid prepared query: invalid " +
+                    NsonProtocol.readable(field) + " count");
+            }
+            return numBranches;
         }
 
         private static VirtualScan readVirtualScan(ByteInputStream in)
@@ -1488,6 +1557,8 @@ public class NsonSerializerFactory implements SerializerFactory {
             }
             writeMapField(ns, OP_CODE, OpCode.WRITE_MULTIPLE.ordinal());
             writeMapField(ns, TIMEOUT, rq.getTimeoutInternal());
+            writeMapField(ns, TOPO_SEQ_NUM, rq.topoSeqNum());
+            writeStoreTopoSeqs(ns, rq.getStoreTopoSeqNums());
             endMap(ns, HEADER);
 
             /*
@@ -1598,6 +1669,8 @@ public class NsonSerializerFactory implements SerializerFactory {
                     }
                 } else if (name.equals(TOPOLOGY_INFO)) {
                     readTopologyInfo(in, result);
+                } else if (name.equals(STORE_TOPOLOGY_INFO)) {
+                    readStoreTopoInfo(in, result);
                 } else {
                     skipUnknownField(walker, name);
                 }
@@ -2398,6 +2471,7 @@ public class NsonSerializerFactory implements SerializerFactory {
          *  version (int)
          *  operation (int)
          *  sequence number of cached topology, if available
+         *  per-store topology sequence number, if available
          *  timeout (int)
          *  tableName if available
          *   it is helpful to have the tableName available as early as possible
@@ -2415,6 +2489,7 @@ public class NsonSerializerFactory implements SerializerFactory {
             }
             writeMapField(ns, OP_CODE, op);
             writeMapField(ns, TOPO_SEQ_NUM, rq.topoSeqNum());
+            writeStoreTopoSeqs(ns, rq.getStoreTopoSeqNums());
             writeMapField(ns, TIMEOUT, rq.getTimeoutInternal());
             if (rq.getPreferThrottling()) {
                 writeMapField(ns, PREFER_THROTTLING, true);
@@ -2422,6 +2497,38 @@ public class NsonSerializerFactory implements SerializerFactory {
             if (rq.getDRLOptIn()) {
                 writeMapField(ns, DRL_OPTIN, true);
             }
+        }
+
+        /**
+         * Writes per-store topology sequence numbers in the request header.
+         * Each entry identifies a store and its cached topology sequence, it
+         * does not include shard IDs.
+         *
+         * STORE_TOPO_SEQ_NUMS: [
+         *   {
+         *     STORE_ID: string,
+         *     TOPO_SEQ_NUM: integer
+         *   },
+         *   ..
+         * ]
+         */
+        protected static void writeStoreTopoSeqs(NsonSerializer ns,
+                                                 Map<String, Integer> topoSeqs)
+            throws IOException {
+
+            if (topoSeqs == null) {
+                return;
+            }
+
+            startArray(ns, STORE_TOPO_SEQ_NUMS);
+            for (Map.Entry<String, Integer> e : topoSeqs.entrySet()) {
+                ns.startMap(0);
+                writeMapField(ns, STORE_ID, e.getKey());
+                writeMapField(ns, TOPO_SEQ_NUM, e.getValue());
+                ns.endMap(0);
+                ns.incrSize(1);
+            }
+            endArray(ns, STORE_TOPO_SEQ_NUMS);
         }
 
         /**
@@ -2776,13 +2883,14 @@ public class NsonSerializerFactory implements SerializerFactory {
         }
 
         /*
+         * Read the legacy global topology information:
+         *
          * "topology_info" : {
          *    "PROXY_TOPO_SEQNUM" : int
          *    "SHARD_IDS" : [ int, ... ]
          * }
          */
-        static void readTopologyInfo(ByteInputStream in,
-                                             Result result)
+        static void readTopologyInfo(ByteInputStream in, Result result)
             throws IOException {
 
             int proxyTopoSeqNum = -1;
@@ -2806,6 +2914,88 @@ public class NsonSerializerFactory implements SerializerFactory {
                 ti = new TopologyInfo(proxyTopoSeqNum, shardIds);
                 result.setTopology(ti);
             }
+        }
+
+        /*
+         * Reads the per-store topology array.
+         *
+         * "STORE_TOPOLOGY_INFO" : [
+         *   {
+         *     "STORE_ID": string,
+         *     "PROXY_TOPO_SEQNUM" : int,
+         *     "SHARD_IDS" : [ int, ... ]
+         *   },
+         *   ...
+         * ]
+         */
+        protected static void readStoreTopoInfo(ByteInputStream in,
+                                                Result result)
+            throws IOException {
+
+            readType(in, Nson.TYPE_ARRAY);
+            in.readInt(); /* length of array in bytes */
+            int numTopos = in.readInt();
+            if (numTopos < 0 || numTopos > MAX_STORES) {
+                throw new IllegalArgumentException(
+                    "Invalid number of topology entries: " + numTopos);
+            }
+
+            ArrayList<TopologyInfo> storeTopos = new ArrayList<>(numTopos);
+            for (int i = 0; i < numTopos; ++i) {
+                TopologyInfo ti = readStoreTopoEntry(in);
+                if (ti != null) {
+                    storeTopos.add(ti);
+                }
+            }
+
+            result.setStoreTopologies(storeTopos);
+        }
+
+        /*
+         * Reads a store topology entry:
+         *  {
+         *    "STORE_ID" : string,
+         *    "PROXY_TOPO_SEQNUM" : int,
+         *    "SHARD_IDS" : [ int, ... ]
+         *  }
+         */
+        private static TopologyInfo readStoreTopoEntry(ByteInputStream in)
+            throws IOException {
+
+            String storeName = null;
+            int proxyTopoSeqNum = -1;
+            int[] shardIds = null;
+            MapWalker walker = new MapWalker(in);
+
+            while (walker.hasNext()) {
+                walker.next();
+                String name = walker.getCurrentName();
+                if (name.equals(STORE_ID)) {
+                    storeName = Nson.readNsonString(in);
+                } else if (name.equals(PROXY_TOPO_SEQNUM)) {
+                    proxyTopoSeqNum = Nson.readNsonInt(in);
+                } else if (name.equals(SHARD_IDS)) {
+                    shardIds = readNsonIntArray(in);
+                } else {
+                    skipUnknownField(walker, name);
+                }
+            }
+
+            if (storeName == null) {
+                throw new IllegalArgumentException(
+                    "Per-store topology entry is missing store id");
+            }
+            if (proxyTopoSeqNum < 0) {
+                throw new IllegalArgumentException(
+                    "Per-store topology entry has invalid topoSeqNum: " +
+                    proxyTopoSeqNum);
+            }
+            if (shardIds == null) {
+                throw new IllegalArgumentException(
+                    "Per-store topology entry is missing shard IDs");
+            }
+
+            return new TopologyInfo(storeName, proxyTopoSeqNum, shardIds);
         }
 
         // TODO: move this to Nson

--- a/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/QueryDriver.java
@@ -8,9 +8,12 @@
 package oracle.nosql.driver.query;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import oracle.nosql.driver.NoSQLException;
+import oracle.nosql.driver.PrepareQueryException;
 import oracle.nosql.driver.RequestTimeoutException;
 import oracle.nosql.driver.RetryableException;
 import oracle.nosql.driver.http.Client;
@@ -58,6 +61,13 @@ public class QueryDriver {
     private RuntimeControlBlock theRCB;
 
     /*
+     * The topology snapshots used by all requests during this execution.
+     * When per-store topology is enabled, the array contains one snapshot for
+     * each query branch. Otherwise, it contains the single legacy snapshot.
+     */
+    private TopologyInfo[] theBaseTopos;
+
+    /*
      * The max number of results the app will receive per NoSQLHandle.query()
      * invocation
      */
@@ -83,6 +93,62 @@ public class QueryDriver {
 
     QueryRequest getRequest() {
         return theRequest;
+    }
+
+    TopologyInfo[] getBaseTopos() {
+        if (theBaseTopos == null) {
+            initializeBaseTopos();
+        }
+        return theBaseTopos;
+    }
+
+    /*
+     * Freezes the topologies used by this query execution and records their
+     * sequence numbers on the request.
+     */
+    private void initializeBaseTopos() {
+        TopologyInfo legacyTopo = theClient.getTopology();
+        Map<String, TopologyInfo> storeTopos = theClient.getStoreTopoSnapshot();
+
+        PreparedStatement prep = theRequest.getPreparedStatement();
+        String branchStoreName = prep.getBranchStoreName(0);
+        if (branchStoreName == null) {
+            if (legacyTopo == null) {
+                throw new PrepareQueryException(
+                    "Missing legacy topology for prepared query. " +
+                    "Prepare the query again.");
+            }
+            theBaseTopos = new TopologyInfo[] { legacyTopo };
+        } else {
+            int numBranches = prep.getNumBranches();
+            theBaseTopos = new TopologyInfo[numBranches];
+            for (int branch = 0; branch < numBranches; ++branch) {
+                branchStoreName = prep.getBranchStoreName(branch);
+                TopologyInfo topo = storeTopos.get(branchStoreName);
+                if (topo == null) {
+                    throw new PrepareQueryException(
+                        "Missing topology for prepared query store " +
+                        branchStoreName + ". Prepare the query again.");
+                }
+                theBaseTopos[branch] = topo;
+            }
+        }
+
+        /*
+         * The initial query request is stamped with the cached topology before
+         * it is sent to the proxy. Its prepare response may then refresh the
+         * client cache. The driver plan above uses the refreshed cache, so
+         * update this request as well. Internal requests copy these fields;
+         * without this update, they could send the old topology while the
+         * driver plan executes with the refreshed topology.
+         */
+        Map<String, Integer> storeTopoSeqs = new HashMap<>();
+        for (Map.Entry<String, TopologyInfo> e : storeTopos.entrySet()) {
+            storeTopoSeqs.put(e.getKey(), e.getValue().getSeqNum());
+        }
+        theRequest.setExecutionTopology(
+            (legacyTopo == null ? -1 : legacyTopo.getSeqNum()),
+            storeTopoSeqs);
     }
 
     public RuntimeControlBlock getRCB() {

--- a/driver/src/main/java/oracle/nosql/driver/query/RuntimeControlBlock.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/RuntimeControlBlock.java
@@ -30,7 +30,12 @@ public class RuntimeControlBlock {
      */
     private final QueryDriver theQueryDriver;
 
-    private final TopologyInfo theBaseTopo;
+    /*
+     * The topology snapshots used by all requests during this execution.
+     * When per-store topology is enabled, the array contains one snapshot for
+     * each query branch. Otherwise, it contains the single legacy snapshot.
+     */
+    private final TopologyInfo[] theBaseTopos;
 
     /*
      * An array storing the values of the extenrnal variables set for the
@@ -99,7 +104,7 @@ public class RuntimeControlBlock {
         theIteratorStates = new PlanIterState[numIters];
         theRegisters = new FieldValue[numRegs];
         theExternalVars = externalVars;
-        theBaseTopo = getClient().getTopology();
+        theBaseTopos = driver.getBaseTopos();
     }
 
     public int getTraceLevel() {
@@ -139,7 +144,10 @@ public class RuntimeControlBlock {
     }
 
     TopologyInfo getBaseTopo() {
-        return theBaseTopo;
+        if (theBaseTopos.length == 1) {
+            return theBaseTopos[0];
+        }
+        return theBaseTopos[theUnionBranch];
     }
 
     Consistency getConsistency() {
@@ -201,10 +209,6 @@ public class RuntimeControlBlock {
 
     void setUnionBranch(int b) {
         theUnionBranch = b;
-    }
-
-    void incUnionBranch() {
-        ++theUnionBranch;
     }
 
     public void setState(int pos, PlanIterState state) {

--- a/driver/src/main/java/oracle/nosql/driver/query/TopologyInfo.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/TopologyInfo.java
@@ -8,19 +8,40 @@
 package oracle.nosql.driver.query;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class TopologyInfo {
 
-    private int theSeqNum = -1;
+    private final String theStoreName;
 
-    private int[] theShardIds;
+    private final int theSeqNum;
+
+    private final int[] theShardIds;
 
     public TopologyInfo(int seqNum, int[] shardIds) {
-        if (shardIds == null) {
-            throw new IllegalArgumentException("TopologyInfo shardIds must not be null");
+        this(null, seqNum, shardIds);
+    }
+
+    public TopologyInfo(String storeName, int seqNum, int[] shardIds) {
+        if (storeName != null && storeName.isBlank()) {
+            throw new IllegalArgumentException(
+                "TopologyInfo storeName must not be empty string");
         }
+        if (seqNum < 0) {
+            throw new IllegalArgumentException(
+                "TopologyInfo seqNum must not be negative");
+        }
+        if (shardIds == null || shardIds.length == 0) {
+            throw new IllegalArgumentException(
+                "TopologyInfo shardIds must not be null or empty");
+        }
+        theStoreName = storeName;
         theSeqNum = seqNum;
         theShardIds = shardIds;
+    }
+
+    public String getStoreName() {
+        return theStoreName;
     }
 
     public int getSeqNum() {
@@ -38,19 +59,19 @@ public class TopologyInfo {
     int getLastShardId() {
         return theShardIds[theShardIds.length-1];
     }
-   
-    int[] getShardIds() {
-        return theShardIds;
-    }
 
     @Override
     public boolean equals(Object o) {
 
+        if (!(o instanceof TopologyInfo)) {
+            return false;
+        }
         TopologyInfo other = (TopologyInfo)o;
 
         if (this == other ||
-            theSeqNum == other.theSeqNum ||
-            Arrays.equals(theShardIds, other.theShardIds)) {
+            (Objects.equals(theStoreName, other.theStoreName) &&
+             theSeqNum == other.theSeqNum &&
+             Arrays.equals(theShardIds, other.theShardIds))) {
             return true;
         }
 
@@ -59,13 +80,20 @@ public class TopologyInfo {
 
     @Override
     public int hashCode() {
-        return theSeqNum;
+        int code = 1;
+        code = 31 * code + (theStoreName != null ? theStoreName.hashCode() : 0);
+        code = 31 * code + theSeqNum;
+        code = 31 * code + Arrays.hashCode(theShardIds);
+        return code;
     }
 
     @Override
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
+        if (theStoreName != null) {
+            sb.append("storeName = ").append(theStoreName).append(" ");
+        }
         sb.append("seqNum = ").append(theSeqNum);
         sb.append(" shards ids = [ ");
         for (int sid : theShardIds) {

--- a/driver/src/main/java/oracle/nosql/driver/query/UnionIter.java
+++ b/driver/src/main/java/oracle/nosql/driver/query/UnionIter.java
@@ -146,14 +146,17 @@ public class UnionIter extends PlanIter {
 
         if (theSortFields == null) {
             PlanIter branch = theBranches[state.theCurrentBranch];
+            rcb.setUnionBranch(state.theCurrentBranch);
             branch.open(rcb);
         } else {
             for (int i = 0; i < theBranches.length; ++i) {
                 PlanIter branch = theBranches[i];
+                rcb.setUnionBranch(i);
                 branch.open(rcb);
                 SortedBranch sb = new SortedBranch(rcb, branch, i);
                 state.theSortedBranches.add(sb);
             }
+            rcb.setUnionBranch(0);
         }
     }
 
@@ -197,6 +200,7 @@ public class UnionIter extends PlanIter {
         while (state.theCurrentBranch < theBranches.length) {
 
             PlanIter branch = theBranches[state.theCurrentBranch];
+            rcb.setUnionBranch(state.theCurrentBranch);
 
             boolean more = branch.next(rcb);
 
@@ -215,7 +219,6 @@ public class UnionIter extends PlanIter {
             }
 
             ++state.theCurrentBranch;
-            rcb.incUnionBranch();
 
             if (rcb.getTraceLevel() >= 3) {
                 rcb.trace("UNION: moved to branch " + state.theCurrentBranch);
@@ -223,6 +226,7 @@ public class UnionIter extends PlanIter {
 
             if (state.theCurrentBranch < theBranches.length) {
                 branch = theBranches[state.theCurrentBranch];
+                rcb.setUnionBranch(state.theCurrentBranch);
                 branch.open(rcb);
 
                 /* For simplicity, we don't want to allow the possibility of

--- a/driver/src/test/java/oracle/nosql/driver/RequestTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/RequestTest.java
@@ -113,7 +113,8 @@ public class RequestTest {
             namespaces,
             tableNames,
             (byte)5,
-            0);
+            0,
+            null);
 
         proxyStatement[0] = 9;
         proxyStatements.set(0, new byte[] {9, 9, 9});
@@ -151,7 +152,8 @@ public class RequestTest {
             namespaces,
             tableNames,
             (byte)5,
-            0);
+            0,
+            null);
         QueryRequest request =
             new QueryRequest().setPreparedStatement(prepared);
 

--- a/driver/src/test/java/oracle/nosql/driver/query/RuntimeControlBlockTest.java
+++ b/driver/src/test/java/oracle/nosql/driver/query/RuntimeControlBlockTest.java
@@ -1,0 +1,302 @@
+/*-
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+package oracle.nosql.driver.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import io.netty.handler.ssl.SslContext;
+import oracle.nosql.driver.AuthorizationProvider;
+import oracle.nosql.driver.NoSQLHandleConfig;
+import oracle.nosql.driver.PrepareQueryException;
+import oracle.nosql.driver.http.Client;
+import oracle.nosql.driver.httpclient.HttpClient;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.Request;
+
+import org.junit.Test;
+
+/**
+ * Tests topology selection and snapshot behavior during advanced query
+ * execution.
+ */
+public class RuntimeControlBlockTest {
+
+    private static String STORE1 = "store1";
+    private static TopologyInfo STORE1_TOPO =
+        new TopologyInfo(STORE1, 10, new int[] { 1, 2 });
+    private static TopologyInfo STORE1_NEW_TOPO =
+        new TopologyInfo("store1", 99, new int[]{ 5, 6 });
+
+    private static String STORE2 = "store2";
+    private static TopologyInfo STORE2_TOPO =
+        new TopologyInfo(STORE2, 20, new int[] { 1, 2, 3, 4});
+
+    private static TopologyInfo LEGACY_TOPO =
+        new TopologyInfo(11, new int[] { 1, 2 });
+
+    /**
+     * Verifies that each UNION branch uses the topology frozen at execution
+     * initialization, even after the client cache is refreshed.
+     */
+    @Test
+    public void testBaseTopologyFrozenPerBranch() {
+
+        TestClient client = new TestClient();
+        try {
+            client.putStoreTopology(STORE1_TOPO);
+            client.putStoreTopology(STORE2_TOPO);
+
+            PreparedStatement pstmt =
+                createPreparedStatement(new String[] {STORE1, STORE2});
+            RuntimeControlBlock rcb = createRuntimeControlBlock(client, pstmt);
+
+            assertEquals(STORE1_TOPO, rcb.getBaseTopo());
+
+            client.putStoreTopology(STORE1_NEW_TOPO);
+            assertEquals(STORE1_TOPO, rcb.getBaseTopo());
+
+            rcb.setUnionBranch(1);
+            assertEquals(STORE2_TOPO, rcb.getBaseTopo());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that a per-store prepared query must be prepared again when its
+     * store topology is missing from the client cache.
+     */
+    @Test
+    public void testMissingBranchTopologyRequiresReprepare() {
+
+        TestClient client = new TestClient();
+        try {
+            PreparedStatement pstmt =
+                createPreparedStatement(new String[]{ STORE1 });
+            assertThrows(PrepareQueryException.class,
+                         () -> createRuntimeControlBlock(client, pstmt));
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that legacy prepared queries require and use the single legacy
+     * topology for every UNION branch.
+     */
+    @Test
+    public void testLegacyPreparedStatementUsesLegacyTopology() {
+
+        TestClient client = new TestClient();
+        try {
+            PreparedStatement pstmt = createPreparedStatement(null);
+            assertThrows(PrepareQueryException.class,
+                         () -> createRuntimeControlBlock(client, pstmt));
+
+            client.setLegacyTopology(LEGACY_TOPO);
+
+            RuntimeControlBlock rcb = createRuntimeControlBlock(client, pstmt);
+            assertEquals(LEGACY_TOPO, rcb.getBaseTopo());
+
+            rcb.setUnionBranch(1);
+            assertEquals(LEGACY_TOPO, rcb.getBaseTopo());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Verifies that internal query requests use sequence numbers matching the
+     * base topology snapshot, rather than a later client-cache refresh.
+     */
+    @Test
+    public void testInternalRequestUsesBaseTopologySnapshot() {
+        TestClient client = new TestClient();
+        try {
+            client.putStoreTopology(STORE1_TOPO);
+
+            PreparedStatement pstmt =
+                createPreparedStatement(new String[] { STORE1 });
+            QueryRequest request = new QueryRequest()
+                .setPreparedStatement(pstmt);
+
+            request.setTopoSeqNum(5);
+            request.setStoreTopoSeqNums(Collections.singletonMap(STORE1, 5));
+
+            QueryDriver driver = new QueryDriver(request);
+            driver.setClient(client);
+            RuntimeControlBlock rcb =
+                new RuntimeControlBlock(driver, null, 1, 1, null);
+
+            client.putStoreTopology(STORE1_NEW_TOPO);
+
+            assertEquals(STORE1_TOPO, rcb.getBaseTopo());
+            assertEquals(-1, request.topoSeqNum());
+            assertEquals(Integer.valueOf(STORE1_TOPO.getSeqNum()),
+                         request.getStoreTopoSeqNums().get(STORE1));
+            assertEquals(request.getStoreTopoSeqNums(),
+                         request.copyInternal().getStoreTopoSeqNums());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    /**
+     * Creates a runtime control block for the supplied prepared statement and
+     * test client.
+     */
+    private RuntimeControlBlock createRuntimeControlBlock(
+        TestClient client,
+        PreparedStatement psmt) {
+
+        QueryRequest request = new QueryRequest()
+            .setPreparedStatement(psmt);
+        QueryDriver driver = new QueryDriver(request);
+        driver.setClient(client);
+        return new RuntimeControlBlock(driver, null, 1, 1, null);
+    }
+
+    /**
+     * Creates a multi-branch prepared statement with optional per-store branch
+     * metadata. A null store list creates a legacy prepared statement.
+     */
+    private PreparedStatement createPreparedStatement(String[] storeNames) {
+
+        int numBranches = (storeNames != null ? storeNames.length : 2);
+        ArrayList<byte[]> proxyStatements = new ArrayList<byte[]>();
+        ArrayList<String> namespaces = new ArrayList<String>();
+        ArrayList<String> tableNames = new ArrayList<String>();
+        ArrayList<String> branchStoreNames =
+            (storeNames != null ? new ArrayList<String>() : null);
+
+        for (int i = 0; i < numBranches; ++i) {
+            proxyStatements.add(new byte[] { (byte)(i + 1) });
+            namespaces.add("ns" + i);
+            tableNames.add("table" + i);
+            if (branchStoreNames != null) {
+                branchStoreNames.add(storeNames[i]);
+            }
+        }
+
+        return new PreparedStatement("select * from table",
+                                     null,
+                                     null,
+                                     proxyStatements,
+                                     null,
+                                     0,
+                                     1,
+                                     null,
+                                     namespaces,
+                                     tableNames,
+                                     (byte)5,
+                                     0,
+                                     branchStoreNames);
+    }
+
+    /**
+     * Creates the minimal handle configuration needed by the test client.
+     */
+    private static NoSQLHandleConfig config() {
+        AuthorizationProvider provider = new AuthorizationProvider() {
+            /**
+             * Returns a stable authorization value for local test requests.
+             */
+            @Override
+            public String getAuthorizationString(Request request) {
+                return "test";
+            }
+
+            /**
+             * Performs no cleanup because the test provider owns no resources.
+             */
+            @Override
+            public void close() {
+            }
+        };
+        return new NoSQLHandleConfig("http://localhost:8080", provider);
+    }
+
+    private static class TestClient extends Client {
+
+        private final Map<String, TopologyInfo> storeTopologies =
+            new HashMap<String, TopologyInfo>();
+
+        private TopologyInfo legacyTopology;
+
+        /**
+         * Creates an isolated client backed by the local test configuration.
+         */
+        TestClient() {
+            super(null, config());
+        }
+
+        /**
+         * Adds or replaces the cached topology for a store.
+         */
+        void putStoreTopology(TopologyInfo topology) {
+            storeTopologies.put(topology.getStoreName(), topology);
+        }
+
+        /**
+         * Sets the topology returned for legacy prepared queries.
+         */
+        void setLegacyTopology(TopologyInfo topology) {
+            legacyTopology = topology;
+        }
+
+        /**
+         * Returns an immutable snapshot of the per-store topology cache.
+         */
+        @Override
+        public Map<String, TopologyInfo> getStoreTopoSnapshot() {
+            return Collections.unmodifiableMap(
+                new HashMap<String, TopologyInfo>(storeTopologies));
+        }
+
+        /**
+         * Returns the topology used by legacy prepared queries.
+         */
+        @Override
+        public TopologyInfo getTopology() {
+            return legacyTopology;
+        }
+
+        /**
+         * Creates the minimal HTTP client required by the test client without
+         * issuing network requests.
+         */
+        @Override
+        protected HttpClient createHttpClient(
+            URL url,
+            NoSQLHandleConfig httpConfig,
+            SslContext sslCtx,
+            Logger logger) {
+
+            return new HttpClient("localhost",
+                                  8080,
+                                  1,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  null,
+                                  0,
+                                  "test",
+                                  null);
+        }
+    }
+}


### PR DESCRIPTION
A proxy can serve more than one NoSQL store. Keeping one shared topology for the proxy can cause a query to use shard information from the wrong store.

**Solution:**
- Track topology separately for each store and send the cached topology version for every known store with each request. 
- Read topology updates and query branch store names from the proxy, then cache them by store.
- For advanced queries, select the needed store topology once when execution starts and use that same snapshot for all later query batches.
- Keep the existing topology behavior for older proxies that do not support per-store topology.

**Changes:**
  - Add per-store topology sequence numbers in the NSON request header: 
    `h.sts: [{ sid: <store name>, ts: <topology sequence> }, ...]`
    The SDK sends both the existing legacy topology sequence and h.sts, allowing proxies to use per-store topology when supported while preserving rolling compatibility.

  - Add per-store topology refreshes in responses: 
     ` stp: [{ sid: <store name>, pn: <topology sequence>, sa: [<shard IDs>] }, ...]` 
   The SDK caches these immutable topology entries by store name. Existing legacy tp response handling remains unchanged.

  - Add "qbs" to prepare/unprepared-query response: `qbs: [string,..]` 
     It is a store-name array aligned with prepared-query branches (qb). The SDK records this branch-to-store mapping in PreparedStatement.

  - For each prepared query batch, serialize the selected branch’s store name as "sid", allowing the proxy to validate the execution branch’s store identity.

  - At advanced-query execution start, the SDK freezes the topology for each query branch from the per-store cache. After a prepare response refreshes the cache, it updates the original request so internal batch requests carry the same topology snapshot used by local scanners.

  - For legacy prepared plans without "qbs", compiled by old proxy, the SDK uses the legacy topology. If it is unavailable, the SDK requires reprepare rather than guessing from cached per-store topology.

  - Binary/V3 topology handling remains legacy-only and unchanged.